### PR TITLE
read the metadata of the SAR image files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,9 @@ repos:
     rev: v3.0.0-alpha.9-for-vscode
     hooks:
       - id: prettier
+  - repo: https://github.com/MarcoGorelli/absolufy-imports
+    rev: v0.3.1
+    hooks:
+      - id: absolufy-imports
+        name: absolufy-imports
+        files: ^ceos_alos2/

--- a/ceos_alos2/datatypes.py
+++ b/ceos_alos2/datatypes.py
@@ -124,3 +124,11 @@ class DatetimeYdus(Adapter):
 
     def _encode(self, obj, context, path):
         raise NotImplementedError
+
+
+class ComplexAdapter(Adapter):
+    def _decode(self, obj, context, path):
+        return obj["real"] + 1j * obj["imaginary"]
+
+    def _encode(self, obj, context, path):
+        return {"real": obj.real, "imaginary": obj.imag}

--- a/ceos_alos2/datatypes.py
+++ b/ceos_alos2/datatypes.py
@@ -116,7 +116,11 @@ class DatetimeYdus(Adapter):
         super().__init__(base)
 
     def _decode(self, obj, context, path):
-        return self.reference_date.date + datetime.timedelta(microseconds=obj)
+        reference_date = (
+            self.reference_date(context) if callable(self.reference_date) else self.reference_date
+        )
+        truncated = datetime.datetime.combine(reference_date.date(), datetime.time.min)
+        return truncated + datetime.timedelta(microseconds=obj)
 
     def _encode(self, obj, context, path):
         raise NotImplementedError

--- a/ceos_alos2/datatypes.py
+++ b/ceos_alos2/datatypes.py
@@ -1,3 +1,5 @@
+import datetime
+
 from construct import Adapter
 from construct import PaddedString as PaddedString_
 from construct import Struct
@@ -83,6 +85,38 @@ class Metadata(Adapter):
 
     def _decode(self, obj, context, path):
         return (obj, self.attrs)
+
+    def _encode(self, obj, context, path):
+        raise NotImplementedError
+
+
+class StripNullBytes(Adapter):
+    def _decode(self, obj, context, path):
+        return obj.strip(b"\x00")
+
+    def _encode(self, obj, context, path):
+        raise NotImplementedError
+
+
+class DatetimeYdms(Adapter):
+    def _decode(self, obj, context, path):
+        base = datetime.datetime(obj["year"], 1, 1)
+        timedelta = datetime.timedelta(days=obj["day_of_year"], milliseconds=obj["milliseconds"])
+
+        return base + timedelta
+
+    def _encode(self, obj, context, path):
+        raise NotImplementedError
+
+
+class DatetimeYdus(Adapter):
+    def __init__(self, base, reference_date):
+        self.reference_date = reference_date
+
+        super().__init__(base)
+
+    def _decode(self, obj, context, path):
+        return self.reference_date.date + datetime.timedelta(microseconds=obj)
 
     def _encode(self, obj, context, path):
         raise NotImplementedError

--- a/ceos_alos2/decoders.py
+++ b/ceos_alos2/decoders.py
@@ -5,7 +5,7 @@ from tlz.dicttoolz import merge
 from tlz.functoolz import curry
 from tlz.itertoolz import identity as passthrough
 
-from .dicttoolz import valsplit
+from ceos_alos2.dicttoolz import valsplit
 
 scene_id_re = re.compile(
     r"""(?x)

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -1,0 +1,35 @@
+import math
+
+from ceos_alos2.sar_image.file_descriptor import file_descriptor_record
+from ceos_alos2.sar_image.signal_data import signal_data_record
+
+
+def parse_chunk(content, element_size):
+    n_elements = len(content) // element_size
+    if n_elements * element_size != len(content):
+        raise ValueError(
+            f"sizes mismatch: chunksize is {n_elements * element_size}"
+            " but got {len(content)} bytes"
+        )
+
+    parser = signal_data_record[n_elements]
+    return parser.parse(content)
+
+
+def read_metadata(f, records_per_chunk=1024):
+    header = file_descriptor_record.parse(f.read(720))
+
+    n_records = header.number_of_sar_data_records
+    record_size = header.sar_data_record_length
+
+    n_chunks = math.ceil(n_records / records_per_chunk)
+    chunksizes = [
+        records_per_chunk
+        if records_per_chunk * (index + 1) <= n_records
+        else n_records - records_per_chunk * index
+        for index in range(n_chunks)
+    ]
+
+    metadata = [parse_chunk(f.read(chunksize), record_size) for chunksize in chunksizes]
+
+    return header, metadata

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -9,11 +9,11 @@ def parse_chunk(content, element_size):
     if n_elements * element_size != len(content):
         raise ValueError(
             f"sizes mismatch: chunksize is {n_elements * element_size}"
-            " but got {len(content)} bytes"
+            f" but got {len(content)} bytes"
         )
 
     parser = signal_data_record[n_elements]
-    return parser.parse(content)
+    return list(parser.parse(content))
 
 
 def read_metadata(f, records_per_chunk=1024):

--- a/ceos_alos2/sar_image/enums.py
+++ b/ceos_alos2/sar_image/enums.py
@@ -1,0 +1,29 @@
+from construct import Adapter, Bytes, Enum, Int8ub, Int16ub, Int32ub, Int64ub
+
+
+class Flag(Adapter):
+    bases = {
+        1: Int8ub,
+        2: Int16ub,
+        4: Int32ub,
+        8: Int64ub,
+    }
+
+    def __init__(self, size):
+        base = self.bases.get(size)
+        if base is None:
+            raise ValueError(f"unsupported size: {size}")
+
+        super().__init__(base)
+
+    def _decode(self, obj, context, path):
+        return bool(obj)
+
+    def _encode(self, obj, context, path):
+        return int(obj)
+
+
+sar_channel_id = Enum(Bytes(2), single_polarization=1, dual_polarization=2, full_polarization=4)
+sar_channel_code = Enum(Bytes(2), L=0, S=1, C=2, X=3, KU=4, KA=5)
+transmitted_pulse_polarization = Enum(Bytes(2), horizontal=0, vertical=1)
+chirp_type_designator = Enum(Bytes(2), linear_fm_chirp=0, phase_modulators=1)

--- a/ceos_alos2/sar_image/enums.py
+++ b/ceos_alos2/sar_image/enums.py
@@ -27,3 +27,4 @@ sar_channel_id = Enum(Int16ub, single_polarization=1, dual_polarization=2, full_
 sar_channel_code = Enum(Int16ub, L=0, S=1, C=2, X=3, KU=4, KA=5)
 pulse_polarization = Enum(Int16ub, horizontal=0, vertical=1)
 chirp_type_designator = Enum(Int16ub, linear_fm_chirp=0, phase_modulators=1)
+platform_position_parameters_update = Enum(Int32ub, repeat=0, update=1)

--- a/ceos_alos2/sar_image/enums.py
+++ b/ceos_alos2/sar_image/enums.py
@@ -1,4 +1,4 @@
-from construct import Adapter, Bytes, Enum, Int8ub, Int16ub, Int32ub, Int64ub
+from construct import Adapter, Enum, Int8ub, Int16ub, Int32ub, Int64ub
 
 
 class Flag(Adapter):
@@ -23,7 +23,7 @@ class Flag(Adapter):
         return int(obj)
 
 
-sar_channel_id = Enum(Bytes(2), single_polarization=1, dual_polarization=2, full_polarization=4)
-sar_channel_code = Enum(Bytes(2), L=0, S=1, C=2, X=3, KU=4, KA=5)
-transmitted_pulse_polarization = Enum(Bytes(2), horizontal=0, vertical=1)
-chirp_type_designator = Enum(Bytes(2), linear_fm_chirp=0, phase_modulators=1)
+sar_channel_id = Enum(Int16ub, single_polarization=1, dual_polarization=2, full_polarization=4)
+sar_channel_code = Enum(Int16ub, L=0, S=1, C=2, X=3, KU=4, KA=5)
+pulse_polarization = Enum(Int16ub, horizontal=0, vertical=1)
+chirp_type_designator = Enum(Int16ub, linear_fm_chirp=0, phase_modulators=1)

--- a/ceos_alos2/sar_image/file_descriptor.py
+++ b/ceos_alos2/sar_image/file_descriptor.py
@@ -1,0 +1,86 @@
+from construct import Struct
+
+from ceos_alos2.common import record_preamble
+from ceos_alos2.datatypes import AsciiInteger, Metadata, PaddedString
+
+file_descriptor_record = Struct(
+    "preamble" / record_preamble,
+    "ascii_ebcdic_flag" / PaddedString(2),
+    "blanks1" / PaddedString(2),
+    "format_control_document_id" / PaddedString(12),
+    "format_control_document_revision_level" / PaddedString(2),
+    "file_design_descriptor_revision_letter" / PaddedString(2),
+    "software_release_and_revision_number" / PaddedString(12),
+    "file_number" / AsciiInteger(4),
+    "file_id" / PaddedString(16),
+    "record_sequence_and_location_type_flag" / PaddedString(4),
+    "location_sequence_number" / AsciiInteger(8),
+    "field_length_of_sequence_number" / AsciiInteger(4),
+    "record_code_and_location_type_flag" / PaddedString(4),
+    "record_code_location" / AsciiInteger(8),
+    "record_code_field_length" / AsciiInteger(4),
+    "record_length_and_location_type_flag" / PaddedString(4),
+    "record_length_location" / AsciiInteger(8),
+    "record_length_field_length" / AsciiInteger(4),
+    "reserved1" / PaddedString(1),
+    "reserved2" / PaddedString(1),
+    "reserved3" / PaddedString(1),
+    "reserved4" / PaddedString(1),
+    "blanks6" / PaddedString(64),
+    "number_of_sar_data_records" / AsciiInteger(6),
+    "sar_data_record_length" / AsciiInteger(6),
+    "reserved5" / PaddedString(24),
+    "sample_group_data"
+    / Struct(
+        "bit_length_per_sample" / AsciiInteger(4),
+        "number_of_samples_per_data_group" / AsciiInteger(4),
+        "number_of_bytes_per_data_group" / AsciiInteger(4),
+        "justification_and_order_of_samples_within_data_group" / PaddedString(4),
+    ),
+    "sar_related_data_in_the_record"
+    / Struct(
+        "number_of_sar_channels" / AsciiInteger(4),
+        "number_of_lines_per_dataset" / AsciiInteger(8),
+        "number_of_left_border_pixels_per_line" / AsciiInteger(4),
+        "number_of_data_groups_per_line" / AsciiInteger(8),
+        "number_of_right_border_pixels_per_line" / AsciiInteger(4),
+        "number_of_top_border_lines" / AsciiInteger(4),
+        "number_of_bottom_border_lines" / AsciiInteger(4),
+        "interleaving_id" / PaddedString(4),
+    ),
+    "record_data_in_the_file"
+    / Struct(
+        "number_of_physical_records_per_line" / AsciiInteger(2),
+        "number_of_physical_records_per_multichannel_line_in_this_file" / AsciiInteger(2),
+        "number_of_bytes_of_prefix_data_per_record" / AsciiInteger(4),
+        "number_of_bytes_of_sar_data_per_record" / AsciiInteger(8),
+        "number_of_bytes_of_suffix_data_per_record" / AsciiInteger(4),
+        "prefix_suffix_repeat_flag" / PaddedString(4),
+    ),
+    "prefix_suffix_data_locators"
+    / Struct(
+        "sample_data_line_number_locator" / PaddedString(8),
+        "sar_channel_number_locator" / PaddedString(8),
+        "time_of_sar_data_line_locator" / PaddedString(8),
+        "left_fill_count_locator" / PaddedString(8),
+        "right_fill_count_locator" / PaddedString(8),
+        "pad_pixels_present_indicator" / PaddedString(4),
+        "blanks" / PaddedString(28),
+        "sar_data_line_quality_code_locator" / PaddedString(8),
+        "calibration_information_field_locator" / PaddedString(8),
+        "gain_values_field_locator" / PaddedString(8),
+        "bias_values_field_locator" / PaddedString(8),
+        "sar_data_format_type_indicator" / PaddedString(28),
+        "sar_data_format_type_code" / PaddedString(4),
+        "number_of_left_fill_bits_within_pixel" / AsciiInteger(4),
+        "number_of_right_fill_bits_within_pixel" / AsciiInteger(4),
+        "maximum_data_range_of_pixel" / Metadata(AsciiInteger(8), start=0),
+        "number_of_burst_data" / Metadata(AsciiInteger(4), start=1),
+        "number_of_lines_per_burst" / Metadata(AsciiInteger(4), start=1),
+    ),
+    "scansar_burst_data_information"
+    / Struct(
+        "number_of_overlap_lines_with_adjacent_bursts" / Metadata(AsciiInteger(4), start=0),
+        "blanks" / PaddedString(260),
+    ),
+)

--- a/ceos_alos2/sar_image/processed_data.py
+++ b/ceos_alos2/sar_image/processed_data.py
@@ -1,0 +1,77 @@
+from construct import Bytes, Computed, Int32ub, Seek, Struct, Tell, this
+
+from ceos_alos2.common import record_preamble
+from ceos_alos2.datatypes import DatetimeYdms, Factor, Metadata, StripNullBytes
+from ceos_alos2.sar_image.enums import (
+    pulse_polarization,
+    sar_channel_code,
+    sar_channel_id,
+)
+
+processed_data_record = Struct(
+    "record_start" / Tell,
+    "preamble" / record_preamble,
+    "general_information"
+    / Struct(
+        "sar_image_data_line_number" / Int32ub,
+        "sar_image_data_record_index" / Int32ub,
+        "actual_count_of_left_fill_pixels" / Int32ub,
+        "actual_count_of_data_pixels" / Int32ub,
+        "actual_count_of_right_fill_pixels" / Int32ub,
+    ),
+    "sensor_parameters"
+    / Struct(
+        "sensor_parameters_update_flag" / Int32ub,
+        "sensor_acquisition_date"
+        / DatetimeYdms(
+            Struct(
+                "year" / Int32ub,
+                "day_of_year" / Int32ub,
+                "milliseconds" / Int32ub,
+            )
+        ),
+        "sar_channel_id" / sar_channel_id,
+        "sar_channel_code" / sar_channel_code,
+        "transmitted_pulse_polarization" / pulse_polarization,
+        "received_pulse_polarization" / pulse_polarization,
+        "prf" / Metadata(Int32ub, units="mHz"),
+        "scan_id" / Int32ub,
+        "slant_range_to_first_pixel" / Metadata(Int32ub, units="m"),
+        "slant_range_to_mid_pixel" / Metadata(Int32ub, units="m"),
+        "slant_range_to_last_pixel" / Metadata(Int32ub, units="m"),
+        "doppler_centroid_value_at_first_pixel" / Metadata(Factor(Int32ub, 1e-3), units="Hz"),
+        "doppler_centroid_value_at_mid_pixel" / Metadata(Factor(Int32ub, 1e-3), units="Hz"),
+        "doppler_centroid_value_at_last_pixel" / Metadata(Factor(Int32ub, 1e-3), units="Hz"),
+        "azimuth_fm_rate_of_first_pixel" / Metadata(Int32ub, units="Hz/ms"),
+        "azimuth_fm_rate_of_mid_pixel" / Metadata(Int32ub, units="Hz/ms"),
+        "azimuth_fm_rate_of_last_pixel" / Metadata(Int32ub, units="Hz/ms"),
+        "look_angle_of_nadir" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "azimuth_squint_angle" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "blanks" / Int32ub,
+    ),
+    "geographic_reference_info"
+    / Struct(
+        "geographic_reference_parameter_update_flag" / Int32ub,
+        "latitude_of_first_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "latitude_of_center_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "latitude_of_last_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "longitude_of_first_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "longitude_of_center_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "longitude_of_last_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "northing_of_first_pixel" / Metadata(Int32ub, units="m"),
+        "blanks1" / StripNullBytes(Bytes(4)),
+        "northing_of_last_pixel" / Metadata(Int32ub, units="m"),
+        "blanks2" / StripNullBytes(Bytes(4)),
+        "easting_of_first_pixel" / Metadata(Int32ub, units="m"),
+        "blanks3" / StripNullBytes(Bytes(4)),
+        "easting_of_last_pixel" / Metadata(Int32ub, units="m"),
+        "line_heading" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "blanks4" / StripNullBytes(Bytes(8)),
+    ),
+    "data"
+    / Struct(
+        "start" / Tell,
+        "size" / Computed(this._.preamble.record_length - (this.start - this._.record_start)),
+        "stop" / Seek(this._.record_start + this._.preamble.record_length),
+    ),
+)

--- a/ceos_alos2/sar_image/signal_data.py
+++ b/ceos_alos2/sar_image/signal_data.py
@@ -117,6 +117,7 @@ signal_data_record = Struct(
     "data"
     / Struct(
         "start" / Tell,
+        "size" / this._.preamble.record_length - (this.start - this._.record_start),
         "stop" / Seek(this._.record_start + this._.preamble.record_length),
     ),
 )

--- a/ceos_alos2/sar_image/signal_data.py
+++ b/ceos_alos2/sar_image/signal_data.py
@@ -3,9 +3,9 @@ from construct import Bytes, Int16ub, Int32ub, Int64ub, Struct
 from ceos_alos2.common import record_preamble
 from ceos_alos2.datatypes import Factor, Metadata
 
-signal_data_record_header = Struct(
+signal_data_record = Struct(
     "preamble" / record_preamble,
-    "prefix_data_general_information"
+    "general_information"
     / Struct(
         "sar_image_data_line_number" / Int32ub,
         "sar_image_data_record_index" / Int32ub,
@@ -13,7 +13,7 @@ signal_data_record_header = Struct(
         "actual_count_of_data_pixels" / Int32ub,
         "actual_count_of_right_fill_pixels" / Int32ub,
     ),
-    "prefix_data_sensor_parameters"
+    "sensor_parameters"
     / Struct(
         "sensor_parameters_update_flag" / Int32ub,
         "sensor_acquisition"
@@ -51,7 +51,7 @@ signal_data_record_header = Struct(
         "data_record_window_position" / Metadata(Int32ub, units="ns"),
         "spare" / Int32ub,
     ),
-    "prefix_data_platform_reference_information"
+    "platform_reference_information"
     / Struct(
         "platform_position_parameters_update_flag" / Int32ub,
         "platform_latitude" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
@@ -79,7 +79,7 @@ signal_data_record_header = Struct(
             "yaw" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
         ),
     ),
-    "prefix_data_sensor_facility_specific_auxiliary_data"
+    "sensor_facility_specific_auxiliary_data"
     / Struct(
         "latitude_of_first_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
         "latitude_of_center_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),

--- a/ceos_alos2/sar_image/signal_data.py
+++ b/ceos_alos2/sar_image/signal_data.py
@@ -97,7 +97,7 @@ signal_data_record = Struct(
             "yaw" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
         ),
     ),
-    "sensor_facility_specific_auxiliary_data"
+    "sensor_and_facility_specific_auxiliary_data"
     / Struct(
         "latitude_of_first_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
         "latitude_of_center_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),

--- a/ceos_alos2/sar_image/signal_data.py
+++ b/ceos_alos2/sar_image/signal_data.py
@@ -1,4 +1,4 @@
-from construct import Bytes, Int32ub, Int64ub, Struct, this
+from construct import Bytes, Int32ub, Int64ub, Seek, Struct, Tell, this
 
 from ceos_alos2.common import record_preamble
 from ceos_alos2.datatypes import (
@@ -18,6 +18,7 @@ from ceos_alos2.sar_image.enums import (
 )
 
 signal_data_record = Struct(
+    "record_start" / Tell,
     "preamble" / record_preamble,
     "general_information"
     / Struct(
@@ -112,5 +113,10 @@ signal_data_record = Struct(
         "blanks" / StripNullBytes(Bytes(60)),
         "alos2_frame_number" / Int32ub,
         "palsar_auxiliary_data" / StripNullBytes(Bytes(256)),
+    ),
+    "data"
+    / Struct(
+        "start" / Tell,
+        "stop" / Seek(this._.record_start + this._.preamble.record_length),
     ),
 )

--- a/ceos_alos2/sar_image/signal_data.py
+++ b/ceos_alos2/sar_image/signal_data.py
@@ -1,0 +1,99 @@
+from construct import Bytes, Int16ub, Int32ub, Int64ub, Struct
+
+from ceos_alos2.common import record_preamble
+from ceos_alos2.datatypes import Factor, Metadata
+
+signal_data_record_header = Struct(
+    "preamble" / record_preamble,
+    "prefix_data_general_information"
+    / Struct(
+        "sar_image_data_line_number" / Int32ub,
+        "sar_image_data_record_index" / Int32ub,
+        "actual_count_of_left_fill_pixels" / Int32ub,
+        "actual_count_of_data_pixels" / Int32ub,
+        "actual_count_of_right_fill_pixels" / Int32ub,
+    ),
+    "prefix_data_sensor_parameters"
+    / Struct(
+        "sensor_parameters_update_flag" / Int32ub,
+        "sensor_acquisition"
+        / Struct(
+            "year" / Int32ub,
+            "day_of_year" / Int32ub,
+            "milliseconds_of_day" / Int32ub,
+        ),
+        "sar_channel_id" / Int16ub,
+        "sar_channel_code" / Int16ub,
+        "transmitted_pulse_polarization" / Int16ub,
+        "received_pulse_polarization" / Int16ub,
+        "prf" / Metadata(Int32ub, units="mHz"),
+        "scan_id" / Int32ub,
+        "onboard_range_compressed_flag" / Int16ub,
+        "chirp_type_designator" / Int16ub,
+        "chirp_length" / Metadata(Int32ub, units="ns"),
+        "chirp_constant_coefficient" / Metadata(Int32ub, units="Hz"),
+        "chirp_linear_coefficient" / Metadata(Int32ub, units="Hz/µs"),
+        "chirp_quadratic_coefficient" / Metadata(Int32ub, units="Hz/µs^2"),
+        "sensor_acquisition_microseconds_of_day" / Int64ub,
+        "receiver_gain" / Metadata(Int32ub, units="dB"),
+        "invalid_line_flag" / Int32ub,
+        "elevation_angle_at_nadir_of_antenna"
+        / Struct(
+            "electronic" / Metadata(Int32ub, units="deg"),
+            "mechanic" / Metadata(Int32ub, units="deg"),
+        ),
+        "antenna_squint_angle"
+        / Struct(
+            "electronic" / Metadata(Int32ub, units="deg"),
+            "mechanic" / Metadata(Int32ub, units="deg"),
+        ),
+        "slant_range_to_first_data_sample" / Metadata(Int32ub, units="m"),
+        "data_record_window_position" / Metadata(Int32ub, units="ns"),
+        "spare" / Int32ub,
+    ),
+    "prefix_data_platform_reference_information"
+    / Struct(
+        "platform_position_parameters_update_flag" / Int32ub,
+        "platform_latitude" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "platform_longitude" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "platform_altitude" / Metadata(Int32ub, units="deg"),
+        "platform_ground_speed" / Metadata(Int32ub, units="cm/s"),
+        "platform_velocity"
+        / Struct(
+            "x" / Metadata(Int32ub, units="cm/s"),
+            "y" / Metadata(Int32ub, units="cm/s"),
+            "z" / Metadata(Int32ub, units="cm/s"),
+        ),
+        "platform_acceleration"
+        / Struct(
+            "x" / Metadata(Int32ub, units="cm/s^2"),
+            "y" / Metadata(Int32ub, units="cm/s^2"),
+            "z" / Metadata(Int32ub, units="cm/s^2"),
+        ),
+        "platform_track_angle" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "platform_true_track_angle" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "platform_attitude"
+        / Struct(
+            "pitch" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+            "roll" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+            "yaw" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        ),
+    ),
+    "prefix_data_sensor_facility_specific_auxiliary_data"
+    / Struct(
+        "latitude_of_first_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "latitude_of_center_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "latitude_of_last_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "longitude_of_first_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "longitude_of_center_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+        "longitude_of_last_pixel" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
+    ),
+    "scansar_burst_data_parameters"
+    / Struct(
+        "burst_number" / Int32ub,
+        "line_number_in_this_burst" / Int32ub,
+        "blanks" / Bytes(60),
+        "alos2_frame_number" / Int32ub,
+        "palsar_auxiliary_data" / Bytes(256),
+    ),
+)

--- a/ceos_alos2/sar_image/signal_data.py
+++ b/ceos_alos2/sar_image/signal_data.py
@@ -1,4 +1,4 @@
-from construct import Bytes, Int32ub, Int64ub, Seek, Struct, Tell, this
+from construct import Bytes, Computed, Int32ub, Int64ub, Seek, Struct, Tell, this
 
 from ceos_alos2.common import record_preamble
 from ceos_alos2.datatypes import (
@@ -117,7 +117,7 @@ signal_data_record = Struct(
     "data"
     / Struct(
         "start" / Tell,
-        "size" / this._.preamble.record_length - (this.start - this._.record_start),
+        "size" / Computed(this._.preamble.record_length - (this.start - this._.record_start)),
         "stop" / Seek(this._.record_start + this._.preamble.record_length),
     ),
 )

--- a/ceos_alos2/sar_leader/__init__.py
+++ b/ceos_alos2/sar_leader/__init__.py
@@ -1,16 +1,16 @@
 from construct import Struct, this
 
-from .attitude import attitude_record
-from .data_quality_summary import data_quality_summary_record
-from .dataset_summary import dataset_summary_record
-from .facility_related_data import (
+from ceos_alos2.sar_leader.attitude import attitude_record
+from ceos_alos2.sar_leader.data_quality_summary import data_quality_summary_record
+from ceos_alos2.sar_leader.dataset_summary import dataset_summary_record
+from ceos_alos2.sar_leader.facility_related_data import (
     facility_related_data_5_record,
     facility_related_data_record,
 )
-from .file_descriptor import file_descriptor_record
-from .map_projection import map_projection_record
-from .platform_position import platform_position_record
-from .radiometric_data import radiometric_data_record
+from ceos_alos2.sar_leader.file_descriptor import file_descriptor_record
+from ceos_alos2.sar_leader.map_projection import map_projection_record
+from ceos_alos2.sar_leader.platform_position import platform_position_record
+from ceos_alos2.sar_leader.radiometric_data import radiometric_data_record
 
 sar_leader = Struct(
     "file_descriptor" / file_descriptor_record,


### PR DESCRIPTION
- [x] towards #3

The SAR image files have a header, and then contain a (large) number of uncompressed data records. This only defines the structure of the SAR image header, because reading all data records at once would consume too much memory.

Todo: ~figure out the byte ranges for each of the data records.~