### PR TITLE
fix the metadata structure and length of the processed data records

### DIFF
--- a/ceos_alos2/sar_image/processed_data.py
+++ b/ceos_alos2/sar_image/processed_data.py
@@ -47,7 +47,7 @@ processed_data_record = Struct(
         "azimuth_fm_rate_of_last_pixel" / Metadata(Int32ub, units="Hz/ms"),
         "look_angle_of_nadir" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
         "azimuth_squint_angle" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
-        "blanks" / Int32ub,
+        "blanks" / StripNullBytes(Bytes(20)),
     ),
     "geographic_reference_info"
     / Struct(
@@ -61,12 +61,11 @@ processed_data_record = Struct(
         "northing_of_first_pixel" / Metadata(Int32ub, units="m"),
         "blanks1" / StripNullBytes(Bytes(4)),
         "northing_of_last_pixel" / Metadata(Int32ub, units="m"),
-        "blanks2" / StripNullBytes(Bytes(4)),
         "easting_of_first_pixel" / Metadata(Int32ub, units="m"),
-        "blanks3" / StripNullBytes(Bytes(4)),
+        "blanks2" / StripNullBytes(Bytes(4)),
         "easting_of_last_pixel" / Metadata(Int32ub, units="m"),
         "line_heading" / Metadata(Factor(Int32ub, 1e-6), units="deg"),
-        "blanks4" / StripNullBytes(Bytes(8)),
+        "blanks3" / StripNullBytes(Bytes(8)),
     ),
     "data"
     / Struct(


### PR DESCRIPTION
- [x] follow-up to #7

The documentation claims to occupy bytes 109-128 using a blank of just 4 bytes, which should be 20 bytes. Also, I appear to have mistakenly inserted an additional 4 byte blank between bytes 165-168 and bytes 169-172.