### PR TITLE
read the SAR trailer files

### DIFF
--- a/ceos_alos2/sar_trailer/__init__.py
+++ b/ceos_alos2/sar_trailer/__init__.py
@@ -1,0 +1,28 @@
+import itertools
+
+from ceos_alos2.sar_trailer.file_descriptor import file_descriptor_record
+from ceos_alos2.sar_trailer.image_data import parse_image_data
+
+
+def read_sar_trailer(f):
+    header = file_descriptor_record.parse(f.read(720))
+    data = f.read()
+
+    data_sizes = [record["record_length"] for record in header.low_resolution_image_sizes]
+    offsets = list(itertools.accumulate(data_sizes, initial=0))
+
+    ranges = list(zip(offsets, offsets[1:]))
+    shapes = [
+        (record["number_of_pixels"], record["number_of_lines"])
+        for record in header.low_resolution_image_sizes
+    ]
+    n_bytes = [
+        record["number_of_bytes_per_one_sample"] for record in header.low_resolution_image_sizes
+    ]
+
+    low_res_images = [
+        parse_image_data(data[start:stop], shape, n_bytes_)
+        for (start, stop), shape, n_bytes_ in zip(ranges, shapes, n_bytes)
+    ]
+
+    return header, low_res_images

--- a/ceos_alos2/sar_trailer/file_descriptor.py
+++ b/ceos_alos2/sar_trailer/file_descriptor.py
@@ -1,0 +1,65 @@
+from construct import Struct, this
+
+from ceos_alos2.common import record_preamble
+from ceos_alos2.datatypes import AsciiInteger, PaddedString
+
+small_record_info = Struct(
+    "number_of_records" / AsciiInteger(6),
+    "record_length" / AsciiInteger(6),
+)
+big_record_info = Struct(
+    "number_of_records" / AsciiInteger(6),
+    "record_length" / AsciiInteger(8),
+)
+low_res_image_size = Struct(
+    "record_length" / AsciiInteger(8),
+    "number_of_pixels" / AsciiInteger(6),
+    "number_of_lines" / AsciiInteger(6),
+    "number_of_bytes_per_one_sample" / AsciiInteger(6),
+)
+file_descriptor_record = Struct(
+    "preamble" / record_preamble,
+    "ascii_ebcdic_code" / PaddedString(2),
+    "blanks1" / PaddedString(2),
+    "format_control_document_id" / PaddedString(12),
+    "format_control_document_revision_number" / PaddedString(2),
+    "record_format_revision_level" / PaddedString(2),
+    "software_release_and_revision_number" / PaddedString(12),
+    "file_number" / AsciiInteger(4),
+    "file_id" / PaddedString(16),
+    "record_sequence_and_location_type_flag" / PaddedString(4),
+    "sequence_number_of_location" / AsciiInteger(8),
+    "field_length_of_sequence_number" / AsciiInteger(4),
+    "record_code_and_location_type_flag" / PaddedString(4),
+    "location_of_record_code" / AsciiInteger(8),
+    "field_length_of_record_code" / AsciiInteger(4),
+    "record_length_and_location_type_flag" / PaddedString(4),
+    "location_of_record_length" / AsciiInteger(8),
+    "field_length_of_record_length" / AsciiInteger(4),
+    "blanks1" / PaddedString(68),
+    "dataset_summary" / small_record_info,
+    "map_projection" / small_record_info,
+    "platform_position" / small_record_info,
+    "attitude" / small_record_info,
+    "radiometric_data" / small_record_info,
+    "radiometric_compensation" / small_record_info,
+    "data_quality_summary" / small_record_info,
+    "data_histogram" / small_record_info,
+    "range_spectra" / small_record_info,
+    "dem_descriptor" / small_record_info,
+    "radar_parameter_update" / small_record_info,
+    "annotation_data" / small_record_info,
+    "detail_processing" / small_record_info,
+    "calibration" / small_record_info,
+    "gcp" / small_record_info,
+    "spare" / PaddedString(60),
+    "facility_related_data_1" / big_record_info,
+    "facility_related_data_2" / big_record_info,
+    "facility_related_data_3" / big_record_info,
+    "facility_related_data_4" / big_record_info,
+    "facility_related_data_5" / big_record_info,
+    "number_of_low_resolution_images" / AsciiInteger(6),
+    "low_resolution_image_sizes" / low_res_image_size[this.number_of_low_resolution_images],
+    "blanks"
+    / PaddedString(720 - 522 - this.number_of_low_resolution_images * low_res_image_size.sizeof()),
+)

--- a/ceos_alos2/sar_trailer/image_data.py
+++ b/ceos_alos2/sar_trailer/image_data.py
@@ -1,0 +1,7 @@
+import numpy as np
+
+
+def parse_image_data(content, shape, n_bytes):
+    dtype = np.dtype(f">i{n_bytes}")
+
+    return np.frombuffer(content, dtype).reshape(shape)


### PR DESCRIPTION
- [x] towards #3

The SAR trailer file contains (in addition to the record counts / lengths that are also present in the SAR leader file's file descriptor record) low-resolution images.

However, for the files I checked those low-res images appear to be mostly 0 or -1 when read as big-endian signed short (2-byte signed integer with big-endian byte order), so the reader itself might contain a bug.