### PR TITLE
high-level object for I/O

### DIFF
--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -1,0 +1,119 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+from tlz.itertoolz import first, get, groupby, partition_all, second
+
+
+def unique(iterable):
+    return tuple(dict.fromkeys(iterable))
+
+
+def determine_nearest_chunksize(sizes, reference_size):
+    diff = np.cumsum(sizes) - reference_size
+    index = np.argmin(abs(diff))
+
+    return index + 1
+
+
+def compute_chunk_ranges(byte_ranges, chunks):
+    partitioned = partition_all(chunks, byte_ranges)
+
+    return {
+        chunk_number: (min(map(first, ranges_)), max(map(second, ranges_)))
+        for chunk_number, ranges_ in enumerate(partitioned)
+    }
+
+
+def to_offset_size(ranges):
+    return [{"offset": start, "size": stop - start} for start, stop in ranges]
+
+
+def compute_chunk_offsets(byte_ranges, chunks):
+    ranges = compute_chunk_ranges(byte_ranges, chunks)
+    return to_offset_size(ranges)
+
+
+def compute_selected_ranges(byte_ranges, indexer):
+    n_rows = len(byte_ranges)
+    selected_rows = range(n_rows)[indexer]
+
+    return get(list(selected_rows), list(enumerate(byte_ranges)))
+
+
+def groupby_chunks(byte_ranges, chunksize):
+    grouped = groupby(lambda it: it[0] // chunksize, byte_ranges)
+    return {key: value for key, (_, value) in grouped.items()}
+
+
+def merge_chunk_info(selected, chunk_offsets):
+    return [(chunk_offsets[index], ranges) for index, ranges in selected.items()]
+
+
+def relocate_ranges(chunk_info, ranges):
+    offset = chunk_info["offset"]
+
+    return chunk_info, [(min_ - offset, max_ - offset) for min_, max_ in ranges]
+
+
+def extract_ranges(content, ranges):
+    return [content[start:stop] for start, stop in ranges]
+
+
+def read_chunk(f, offset, size):
+    f.seek(offset)
+
+    return f.read(size)
+
+
+@dataclass(order=False, unsafe_hash=True)
+class Array:
+    """2d array from chunked data"""
+
+    # TODO: decide whether having a cached file object or fs instance and url are better
+    # file location / access
+    fs: Any = field(repr=False)
+    url: str = field(repr=True)
+
+    # data positions
+    byte_ranges: list[tuple[int, int]] = field(repr=False)
+
+    # array information
+    shape: tuple[int, int] = field(repr=True)
+    dtype: str | np.dtype = field(repr=True)
+
+    # convert raw bytes to data
+    parse_bytes: callable = field(repr=False)
+
+    # chunk sizes: chunks in (rows, cols)
+    chunks: tuple[int, int] = field(repr=True, default=None)
+    chunk_offsets: list[tuple[int, int]] = field(repr=False, init=False)
+
+    def __post_init__(self):
+        sizes = np.array([stop - start for start, stop in self.byte_ranges])
+        possible_chunksizes = np.cumsum(sizes)
+        if self.chunks is None:
+            self.chunks = (1, self.shape[1])
+        elif self.chunks == "auto":
+            reference_size = 100 * 2**20
+            rows_per_chunk = determine_nearest_chunksize(possible_chunksizes, reference_size)
+            self.chunks = (rows_per_chunk, self.shape[1])
+        self.chunk_offsets = compute_chunk_offsets(self.byte_ranges, self.chunks[0])
+
+    def __getitem__(self, indexers):
+        rows_per_chunk = self.chunks[0]
+
+        selected_ranges = compute_selected_ranges(self.byte_ranges, indexers[0])
+        grouped = groupby_chunks(selected_ranges, chunksize=rows_per_chunk)
+        merged = merge_chunk_info(grouped, chunk_offsets=self.chunk_offsets)
+        tasks = [relocate_ranges(info, ranges) for info, ranges in merged]
+
+        with self.fs.open(self.url, mode="rb") as f:
+            data = []
+            for chunk_info, ranges in tasks:
+                chunk = read_chunk(f, **chunk_info)
+                raw_bytes = extract_ranges(chunk, ranges)
+                chunk_data = [self.parse_bytes(part) for part in raw_bytes]
+                data.extend(chunk_data)
+
+            return np.stack(data, axis=0)

--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -135,3 +135,7 @@ class Array:
 
         new_indexers = tuple(cons(slice(None), indexers[1:]))
         return data[new_indexers]
+
+    @property
+    def ndim(self):
+        return len(self.shape)

--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -45,7 +45,7 @@ def compute_selected_ranges(byte_ranges, indexer):
 
 def groupby_chunks(byte_ranges, chunksize):
     grouped = groupby(lambda it: it[0] // chunksize, byte_ranges)
-    return {key: value for key, (_, value) in grouped.items()}
+    return {key: [value for _, value in ranges] for key, ranges in grouped.items()}
 
 
 def merge_chunk_info(selected, chunk_offsets):

--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -106,7 +106,7 @@ class Array:
         sizes = np.array([stop - start for start, stop in self.byte_ranges])
         possible_chunksizes = np.cumsum(sizes)
         if self.chunks is None:
-            self.chunks = (1, self.shape[1])
+            self.chunks = (4096, self.shape[1])
         elif self.chunks == "auto":
             reference_size = 100 * 2**20
             rows_per_chunk = determine_nearest_chunksize(possible_chunksizes, reference_size)

--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -32,9 +32,15 @@ def compute_chunk_offsets(byte_ranges, chunks):
 
 def compute_selected_ranges(byte_ranges, indexer):
     n_rows = len(byte_ranges)
-    selected_rows = range(n_rows)[indexer]
+    if isinstance(indexer, int):
+        indexer = [indexer]
 
-    return get(list(selected_rows), list(enumerate(byte_ranges)))
+    if isinstance(indexer, slice):
+        selected_rows = range(n_rows)[indexer]
+    else:
+        selected_rows = indexer
+
+    return list(get(list(selected_rows), list(enumerate(byte_ranges))))
 
 
 def groupby_chunks(byte_ranges, chunksize):

--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -6,6 +6,15 @@ from tlz.functoolz import juxt
 from tlz.itertoolz import first, get, groupby, partition_all, second
 
 
+def normalize_chunks(chunks, shape):
+    def normalize(chunksize, dim_size):
+        if chunksize in (None, -1) or chunksize > dim_size:
+            return dim_size
+        return chunksize
+
+    return tuple(normalize(chunksize, dim_size) for chunksize, dim_size in zip(chunks, shape))
+
+
 def determine_nearest_chunksize(sizes, reference_size):
     diff = np.cumsum(sizes) - reference_size
     index = np.argmin(abs(diff))
@@ -101,6 +110,8 @@ class Array:
             reference_size = 100 * 2**20
             rows_per_chunk = determine_nearest_chunksize(possible_chunksizes, reference_size)
             self.chunks = (rows_per_chunk, self.shape[1])
+        else:
+            self.chunks = normalize_chunks(self.chunks, self.shape)
         self.chunk_offsets = compute_chunk_offsets(self.byte_ranges, self.chunks[0])
 
     def __getitem__(self, indexers):

--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -5,10 +5,6 @@ import numpy as np
 from tlz.itertoolz import first, get, groupby, partition_all, second
 
 
-def unique(iterable):
-    return tuple(dict.fromkeys(iterable))
-
-
 def determine_nearest_chunksize(sizes, reference_size):
     diff = np.cumsum(sizes) - reference_size
     index = np.argmin(abs(diff))

--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
+from tlz.functoolz import juxt
 from tlz.itertoolz import first, get, groupby, partition_all, second
 
 
@@ -108,7 +109,7 @@ class Array:
         selected_ranges = compute_selected_ranges(self.byte_ranges, indexers[0])
         grouped = groupby_chunks(selected_ranges, chunksize=rows_per_chunk)
         merged = merge_chunk_info(grouped, chunk_offsets=self.chunk_offsets)
-        tasks = [relocate_ranges(info, ranges) for info, ranges in merged]
+        tasks = [juxt(first, relocate_ranges)(info, ranges) for info, ranges in merged]
 
         with self.fs.open(self.url, mode="rb") as f:
             data = []

--- a/ceos_alos2/decoders.py
+++ b/ceos_alos2/decoders.py
@@ -120,6 +120,9 @@ def decode_product_id(product_id):
 
 
 def decode_scan_info(scan_info):
+    if scan_info is None:
+        return {}
+
     match = scan_info_re.fullmatch(scan_info)
     if match is None:
         raise ValueError(f"invalid scan info: {scan_info}")

--- a/ceos_alos2/file.py
+++ b/ceos_alos2/file.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
@@ -43,10 +44,25 @@ class Variable:
 
 
 @dataclass(frozen=True)
-class Group:
-    groups: dict[str, "Group"]
-    variables: dict[str, Variable]
+class Group(Mapping):
+    path: str
     attrs: dict[str, Any]
+
+    @property
+    def name(self):
+        if "/" not in self.path:
+            return self.path
+
+        _, name = self.rsplit("/", 1)
+        return name
+
+    @property
+    def groups(self):
+        return [el for el in self.values() if isinstance(el, Group)]
+
+    @property
+    def variables(self):
+        return [el for el in self.values() if isinstance(el, Variable)]
 
 
 class File:

--- a/ceos_alos2/file.py
+++ b/ceos_alos2/file.py
@@ -1,0 +1,148 @@
+from dataclasses import dataclass
+from typing import Any
+
+import fsspec
+from fsspec.implementations.dirfs import DirFileSystem
+from rich.console import Console
+from tlz.functoolz import curry
+
+from ceos_alos2 import sar_image
+from ceos_alos2.array import Array
+
+# from ceos_alos2.sar_leader import sar_leader_record
+from ceos_alos2.summary import parse_summary
+
+# from ceos_alos2.utils import to_dict
+
+# from ceos_alos2.volume_directory import volume_directory_record
+
+console = Console()
+
+
+@dataclass(frozen=True)
+class Variable:
+    dims: str | list[str]
+    data: Array
+    attrs: dict[str, Any]
+
+    @property
+    def ndim(self):
+        return self.data.ndim
+
+    @property
+    def shape(self):
+        return self.data.shape
+
+    @property
+    def dtype(self):
+        return self.data.dtype
+
+    @property
+    def chunks(self):
+        return self.data.chunks
+
+
+@dataclass(frozen=True)
+class Group:
+    groups: dict[str, "Group"]
+    variables: dict[str, Variable]
+    attrs: dict[str, Any]
+
+
+class File:
+    def read_image(self, fs, path):
+        with fs.open(path, mode="rb") as f:
+            header, metadata = sar_image.read_metadata(f, self.chunks[0])
+
+        byte_ranges = [(m.data.start, m.data.stop) for m in metadata]
+        type_code = sar_image.extract_format_type(header)
+        parser = curry(sar_image.parse_data, type_code=type_code)
+
+        shape = sar_image.extract_shape(header)
+        dtype = sar_image.extract_dtype(header)
+
+        image_data = Array(
+            fs=fs,
+            url=path,
+            byte_ranges=byte_ranges,
+            shape=shape,
+            dtype=dtype,
+            parse_bytes=parser,
+            chunks=self.chunks,
+        )
+
+        # transform metadata:
+        # - group attrs
+        # - coords
+        # - image variable attrs
+        group_attrs = sar_image.extract_attrs(header)
+        coords, var_attrs = sar_image.transform_metadata(metadata)
+        image_variable = (["rows", "columns"], image_data, var_attrs)
+
+        raw_variables = coords | {"data": image_variable}
+        variables = {name: Variable(*var) for name, var in raw_variables.items()}
+
+        return Group(groups={}, variables=variables, attrs=group_attrs)
+
+    def __init__(self, url_or_dirfs, chunks=None, **options):
+        if isinstance(url_or_dirfs, DirFileSystem):
+            self.fs = url_or_dirfs
+        elif isinstance(url_or_dirfs, str):
+            fs, url = fsspec.core.url_to_fs(url_or_dirfs)
+            self.fs = DirFileSystem(path=url, fs=fs)
+        else:
+            raise ValueError(f"unkown type: {url_or_dirfs}")
+
+        if chunks is None:
+            chunks = (1024, -1)
+        self.chunks = chunks
+
+        try:
+            with self.fs.open("summary.txt", mode="r") as f:
+                summary = parse_summary(f.read())
+        except FileNotFoundError as e:
+            raise OSError(
+                "Cannot find the summary file (`summary.txt`)."
+                f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
+            ) from e
+
+        fnames = summary["Pdi"]["data_files"]
+
+        # try:
+        #     with self.fs.open(fnames["volume_directory"], mode="rb") as f:
+        #         parsed = volume_directory.volume_directory_record.parse(f.read())
+        #         vol_attrs = volume_directory.extract_metadata(parsed)
+        # except FileNotFoundError as e:
+        #     raise OSError(
+        #         f"Cannot find the volume directory file (`{fnames['volume_directory']}`)."
+        #         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
+        #     )
+
+        # try:
+        #     with self.fs.open(fnames["sar_leader"], mode="rb") as f:
+        #         sar_leader = sar_leader_record.parse(f.read())
+        # except FileNotFoundError as e:
+        #     raise OSError(
+        #         f"Cannot find the sar leader file (`{fnames['sar_leader']}`)."
+        #         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
+        #     )
+
+        image_groups = {
+            sar_image.filename_to_groupname(path): self.read_image(self.fs, path)
+            for path in fnames["sar_imagery"]
+        }
+
+        self._groups = image_groups
+
+        # try:
+        #     with dirfs.open(fnames["sar_trailer"], mode="rb") as f:
+        #         trailer_header, image_ranges = read_sar_trailer_metadata(f)
+        # except FileNotFoundError as e:
+        #     raise OSError(
+        #         f"Cannot find the sar trailer file (`{fnames['sar_trailer']}`)."
+        #         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
+        #     )
+
+    @property
+    def groups(self):
+        return self._groups

--- a/ceos_alos2/file.py
+++ b/ceos_alos2/file.py
@@ -167,3 +167,7 @@ class File:
     @property
     def groups(self):
         return self._groups
+
+    @property
+    def filename(self):
+        return self.fs.path

--- a/ceos_alos2/file.py
+++ b/ceos_alos2/file.py
@@ -5,6 +5,7 @@ from typing import Any
 import fsspec
 from fsspec.implementations.dirfs import DirFileSystem
 from rich.console import Console
+from tlz.dicttoolz import valfilter
 from tlz.functoolz import curry
 
 from ceos_alos2 import sar_image
@@ -58,11 +59,11 @@ class Group(Mapping):
 
     @property
     def groups(self):
-        return [el for el in self.values() if isinstance(el, Group)]
+        return valfilter(lambda el: isinstance(el, Group), self)
 
     @property
     def variables(self):
-        return [el for el in self.values() if isinstance(el, Variable)]
+        return valfilter(lambda el: isinstance(el, Variable), self)
 
 
 class File:

--- a/ceos_alos2/file.py
+++ b/ceos_alos2/file.py
@@ -1,7 +1,6 @@
 import fsspec
 from fsspec.implementations.dirfs import DirFileSystem
 from rich.console import Console
-from tlz.dicttoolz import get_in
 from tlz.functoolz import curry
 
 from ceos_alos2 import sar_image
@@ -18,108 +17,114 @@ from ceos_alos2.summary import parse_summary
 console = Console()
 
 
-class File:
-    def read_image(self, fs, path):
-        with fs.open(path, mode="rb") as f:
-            header, metadata = sar_image.read_metadata(f, self.chunks[0])
+def read_summary(mapper, path):
+    try:
+        bytes_ = mapper[path]
+    except FileNotFoundError as e:
+        raise OSError(
+            f"Cannot find the summary file (`{path}`)."
+            f" Make sure the dataset at {mapper.root} is complete and in the JAXA CEOS format."
+        ) from e
 
-        byte_ranges = [(m.data.start, m.data.stop) for m in metadata]
-        type_code = sar_image.extract_format_type(header)
-        parser = curry(sar_image.parse_data, type_code=type_code)
+    return parse_summary(bytes_.decode())
 
-        shape = sar_image.extract_shape(header)
-        dtype = sar_image.extract_dtype(header)
 
-        image_data = Array(
-            fs=fs,
-            url=path,
-            byte_ranges=byte_ranges,
-            shape=shape,
-            dtype=dtype,
-            parse_bytes=parser,
-            chunks=self.chunks,
-        )
+def read_image(fs, path, chunks):
+    with fs.open(path, mode="rb") as f:
+        header, metadata = sar_image.read_metadata(f, chunks[0])
 
-        # transform metadata:
-        # - group attrs
-        # - coords
-        # - image variable attrs
-        group_attrs = sar_image.extract_attrs(header)
-        coords, var_attrs = sar_image.transform_metadata(metadata)
-        image_variable = (["rows", "columns"], image_data, var_attrs)
+    byte_ranges = [(m.data.start, m.data.stop) for m in metadata]
+    type_code = sar_image.extract_format_type(header)
+    parser = curry(sar_image.parse_data, type_code=type_code)
 
-        raw_variables = coords | {"data": image_variable}
-        variables = {name: Variable(*var) for name, var in raw_variables.items()}
+    shape = sar_image.extract_shape(header)
+    dtype = sar_image.extract_dtype(header)
 
-        return Group(path=None, data=variables, attrs=group_attrs)
+    image_data = Array(
+        fs=fs,
+        url=path,
+        byte_ranges=byte_ranges,
+        shape=shape,
+        dtype=dtype,
+        parse_bytes=parser,
+        chunks=chunks,
+    )
 
-    def __init__(self, url_or_dirfs, chunks=None, **options):
-        if isinstance(url_or_dirfs, DirFileSystem):
-            self.fs = url_or_dirfs
-        elif isinstance(url_or_dirfs, str):
-            fs, url = fsspec.core.url_to_fs(url_or_dirfs)
-            self.fs = DirFileSystem(path=url, fs=fs)
-        else:
-            raise ValueError(f"unkown type: {url_or_dirfs}")
+    # transform metadata:
+    # - group attrs
+    # - coords
+    # - image variable attrs
+    group_attrs = sar_image.extract_attrs(header)
+    coords, var_attrs = sar_image.transform_metadata(metadata)
+    image_variable = (["rows", "columns"], image_data, var_attrs)
 
-        if chunks is None:
-            chunks = (1024, -1)
-        self.chunks = chunks
+    raw_variables = coords | {"data": image_variable}
+    variables = {name: Variable(*var) for name, var in raw_variables.items()}
 
-        try:
-            with self.fs.open("summary.txt", mode="r") as f:
-                summary = parse_summary(f.read())
-        except FileNotFoundError as e:
-            raise OSError(
-                "Cannot find the summary file (`summary.txt`)."
-                f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
-            ) from e
+    group_name = sar_image.filename_to_groupname(path)
 
-        fnames = summary["Pdi"]["data_files"]
+    return Group(path=group_name, data=variables, attrs=group_attrs)
 
-        # try:
-        #     with self.fs.open(fnames["volume_directory"], mode="rb") as f:
-        #         parsed = volume_directory.volume_directory_record.parse(f.read())
-        #         vol_attrs = volume_directory.extract_metadata(parsed)
-        # except FileNotFoundError as e:
-        #     raise OSError(
-        #         f"Cannot find the volume directory file (`{fnames['volume_directory']}`)."
-        #         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
-        #     )
 
-        # try:
-        #     with self.fs.open(fnames["sar_leader"], mode="rb") as f:
-        #         sar_leader = sar_leader_record.parse(f.read())
-        # except FileNotFoundError as e:
-        #     raise OSError(
-        #         f"Cannot find the sar leader file (`{fnames['sar_leader']}`)."
-        #         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
-        #     )
+def open(path, chunks=None, storage_options={}):
+    mapper = fsspec.get_mapper(path, **storage_options)
+    dirfs = DirFileSystem(fs=mapper.fs, path=mapper.root)
 
-        image_groups = {
-            sar_image.filename_to_groupname(path): self.read_image(self.fs, path)
-            for path in fnames["sar_imagery"]
-        }
+    # fill in fallback chunks
+    if chunks is None:
+        chunks = (1024, -1)
 
-        self._groups = image_groups
+    # read summary
+    # TODO: split into metadata for the reader and human-readable metadata
+    summary = read_summary(mapper, "summary.txt")
 
-        # try:
-        #     with dirfs.open(fnames["sar_trailer"], mode="rb") as f:
-        #         trailer_header, image_ranges = read_sar_trailer_metadata(f)
-        # except FileNotFoundError as e:
-        #     raise OSError(
-        #         f"Cannot find the sar trailer file (`{fnames['sar_trailer']}`)."
-        #         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
-        #     )
+    filenames = summary["Pdi"]["data_files"]
 
-    def __getitem__(self, path):
-        parts = path.lstrip("/").split("/")
-        return get_in(parts, self._groups, no_default=True)
+    # read volume directory
+    # read sar leader
+    # read actual imagery
+    imagery_groups = [
+        read_image(dirfs, path, chunks, **storage_options) for path in filenames["sar_imagery"]
+    ]
+    imagery = Group("/imagery", data={group.name: group for group in imagery_groups}, attrs={})
+    # read sar trailer
 
-    @property
-    def groups(self):
-        return self._groups
+    subgroups = {"imagery": imagery}
 
-    @property
-    def filename(self):
-        return self.fs.path
+    return Group(path="/", data=subgroups, attrs={})
+
+
+# try:
+#     with self.fs.open(fnames["volume_directory"], mode="rb") as f:
+#         parsed = volume_directory.volume_directory_record.parse(f.read())
+#         vol_attrs = volume_directory.extract_metadata(parsed)
+# except FileNotFoundError as e:
+#     raise OSError(
+#         f"Cannot find the volume directory file (`{fnames['volume_directory']}`)."
+#         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
+#     )
+
+# try:
+#     with self.fs.open(fnames["sar_leader"], mode="rb") as f:
+#         sar_leader = sar_leader_record.parse(f.read())
+# except FileNotFoundError as e:
+#     raise OSError(
+#         f"Cannot find the sar leader file (`{fnames['sar_leader']}`)."
+#         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
+#     )
+
+# image_groups = {
+#     sar_image.filename_to_groupname(path): self.read_image(self.fs, path)
+#     for path in fnames["sar_imagery"]
+# }
+
+# self._groups = image_groups
+
+# try:
+#     with dirfs.open(fnames["sar_trailer"], mode="rb") as f:
+#         trailer_header, image_ranges = read_sar_trailer_metadata(f)
+# except FileNotFoundError as e:
+#     raise OSError(
+#         f"Cannot find the sar trailer file (`{fnames['sar_trailer']}`)."
+#         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
+#     )

--- a/ceos_alos2/file.py
+++ b/ceos_alos2/file.py
@@ -63,7 +63,7 @@ def read_image(fs, path, chunks):
 
     group_name = sar_image.filename_to_groupname(path)
 
-    return Group(path=group_name, data=variables, attrs=group_attrs)
+    return Group(path=group_name, data=variables, attrs=group_attrs, url=None)
 
 
 def open(path, chunks=None, storage_options={}):
@@ -86,12 +86,14 @@ def open(path, chunks=None, storage_options={}):
     imagery_groups = [
         read_image(dirfs, path, chunks, **storage_options) for path in filenames["sar_imagery"]
     ]
-    imagery = Group("/imagery", data={group.name: group for group in imagery_groups}, attrs={})
+    imagery = Group(
+        "/imagery", url=mapper.root, data={group.name: group for group in imagery_groups}, attrs={}
+    )
     # read sar trailer
 
     subgroups = {"imagery": imagery}
 
-    return Group(path="/", data=subgroups, attrs={})
+    return Group(path="/", data=subgroups, url=mapper.root, attrs={})
 
 
 # try:

--- a/ceos_alos2/file.py
+++ b/ceos_alos2/file.py
@@ -1,15 +1,12 @@
-from collections.abc import Mapping
-from dataclasses import dataclass
-from typing import Any
-
 import fsspec
 from fsspec.implementations.dirfs import DirFileSystem
 from rich.console import Console
-from tlz.dicttoolz import get_in, valfilter
+from tlz.dicttoolz import get_in
 from tlz.functoolz import curry
 
 from ceos_alos2 import sar_image
 from ceos_alos2.array import Array
+from ceos_alos2.hierarchy import Group, Variable
 
 # from ceos_alos2.sar_leader import sar_leader_record
 from ceos_alos2.summary import parse_summary
@@ -19,61 +16,6 @@ from ceos_alos2.summary import parse_summary
 # from ceos_alos2.volume_directory import volume_directory_record
 
 console = Console()
-
-
-@dataclass(frozen=True)
-class Variable:
-    dims: str | list[str]
-    data: Array
-    attrs: dict[str, Any]
-
-    @property
-    def ndim(self):
-        return self.data.ndim
-
-    @property
-    def shape(self):
-        return self.data.shape
-
-    @property
-    def dtype(self):
-        return self.data.dtype
-
-    @property
-    def chunks(self):
-        return self.data.chunks
-
-
-@dataclass(frozen=True)
-class Group(Mapping):
-    path: str
-    data: dict[str, "Group | Variable"]
-    attrs: dict[str, Any]
-
-    def __getitem__(self, item):
-        return self.data[item]
-
-    @property
-    def name(self):
-        if "/" not in self.path:
-            return self.path
-
-        _, name = self.rsplit("/", 1)
-        return name
-
-    def __len__(self):
-        return len(self.keys())
-
-    def __iter__(self):
-        yield from self.keys()
-
-    @property
-    def groups(self):
-        return valfilter(lambda el: isinstance(el, Group), self)
-
-    @property
-    def variables(self):
-        return valfilter(lambda el: isinstance(el, Variable), self)
 
 
 class File:

--- a/ceos_alos2/file.py
+++ b/ceos_alos2/file.py
@@ -5,7 +5,7 @@ from typing import Any
 import fsspec
 from fsspec.implementations.dirfs import DirFileSystem
 from rich.console import Console
-from tlz.dicttoolz import valfilter
+from tlz.dicttoolz import get_in, valfilter
 from tlz.functoolz import curry
 
 from ceos_alos2 import sar_image
@@ -159,6 +159,10 @@ class File:
         #         f"Cannot find the sar trailer file (`{fnames['sar_trailer']}`)."
         #         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
         #     )
+
+    def __getitem__(self, path):
+        parts = path.lstrip("/").split("/")
+        return get_in(parts, self._groups, no_default=True)
 
     @property
     def groups(self):

--- a/ceos_alos2/file.py
+++ b/ceos_alos2/file.py
@@ -49,6 +49,12 @@ class Group(Mapping):
     path: str
     attrs: dict[str, Any]
 
+    def __getitem__(self, path):
+        if path.startswith("/"):
+            raise KeyError(f"absolute paths are not allowed in subgroups: {path}")
+        parts = path.split("/")
+        return get_in(parts, self)
+
     @property
     def name(self):
         if "/" not in self.path:

--- a/ceos_alos2/hierarchy.py
+++ b/ceos_alos2/hierarchy.py
@@ -28,7 +28,7 @@ class Variable:
 
     @property
     def chunks(self):
-        return self.data.chunks
+        return dict(zip(self.dims, self.data.chunks))
 
 
 @dataclass

--- a/ceos_alos2/hierarchy.py
+++ b/ceos_alos2/hierarchy.py
@@ -34,6 +34,7 @@ class Variable:
 @dataclass
 class Group(Mapping):
     path: str | None
+    url: str
     data: dict[str, "Group | Variable"]
     attrs: dict[str, Any]
 
@@ -59,6 +60,9 @@ class Group(Mapping):
                     "group paths need to be either `None`, relative paths,"
                     " or absolute paths below the parent group"
                 )
+
+            if item.url is None:
+                item.url = self.url
 
     def __getitem__(self, item):
         return self.data[item]

--- a/ceos_alos2/hierarchy.py
+++ b/ceos_alos2/hierarchy.py
@@ -76,15 +76,15 @@ class Group(Mapping):
         return name
 
     def __len__(self):
-        return len(self.keys())
+        return len(self.data.keys())
 
     def __iter__(self):
-        yield from self.keys()
+        yield from self.data.keys()
 
     @property
     def groups(self):
-        return valfilter(lambda el: isinstance(el, Group), self)
+        return valfilter(lambda el: isinstance(el, Group), self.data)
 
     @property
     def variables(self):
-        return valfilter(lambda el: isinstance(el, Variable), self)
+        return valfilter(lambda el: isinstance(el, Variable), self.data)

--- a/ceos_alos2/hierarchy.py
+++ b/ceos_alos2/hierarchy.py
@@ -1,0 +1,62 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from tlz.dicttoolz import valfilter
+
+from ceos_alos2.array import Array
+
+
+@dataclass(frozen=True)
+class Variable:
+    dims: str | list[str]
+    data: Array
+    attrs: dict[str, Any]
+
+    @property
+    def ndim(self):
+        return self.data.ndim
+
+    @property
+    def shape(self):
+        return self.data.shape
+
+    @property
+    def dtype(self):
+        return self.data.dtype
+
+    @property
+    def chunks(self):
+        return self.data.chunks
+
+
+@dataclass(frozen=True)
+class Group(Mapping):
+    path: str
+    data: dict[str, "Group | Variable"]
+    attrs: dict[str, Any]
+
+    def __getitem__(self, item):
+        return self.data[item]
+
+    @property
+    def name(self):
+        if "/" not in self.path:
+            return self.path
+
+        _, name = self.rsplit("/", 1)
+        return name
+
+    def __len__(self):
+        return len(self.keys())
+
+    def __iter__(self):
+        yield from self.keys()
+
+    @property
+    def groups(self):
+        return valfilter(lambda el: isinstance(el, Group), self)
+
+    @property
+    def variables(self):
+        return valfilter(lambda el: isinstance(el, Variable), self)

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -115,6 +115,14 @@ def extract_dtype(header):
     return dtype
 
 
+def extract_attrs(header):
+    return {}
+
+
+def transform_metadata(metadata):
+    return {}, {}
+
+
 def parse_data(content, type_code):
     dtype = raw_dtypes.get(type_code)
     if dtype is None:

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -123,6 +123,16 @@ def transform_metadata(metadata):
     return {}, {}
 
 
+def filename_to_groupname(path):
+    from ceos_alos2.decoders import decode_filename
+
+    info = decode_filename(path)
+    scan_number = f"scan{info['scan_number']}" if "scan_number" in info else None
+    polarization = info.get("polarization")
+    parts = [polarization, scan_number]
+    return "_".join([_ for _ in parts if _])
+
+
 def parse_data(content, type_code):
     dtype = raw_dtypes.get(type_code)
     if dtype is None:

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -95,14 +95,28 @@ def extract_shape(header):
     )
 
 
-dtypes = {
+raw_dtypes = {
     "C*8": np.dtype([("real", ">f4"), ("imag", ">f4")]),
     "IU2": np.dtype(">u2"),
 }
 
+dtypes = {
+    "C*8": np.dtype("complex64"),
+    "IU2": np.dtype("uint16"),
+}
+
+
+def extract_dtype(header):
+    type_code = extract_format_type(header)
+    dtype = dtypes.get(type_code)
+    if dtype is None:
+        raise ValueError(f"unknown type code: {type_code}")
+
+    return dtype
+
 
 def parse_data(content, type_code):
-    dtype = dtypes.get(type_code)
+    dtype = raw_dtypes.get(type_code)
     if dtype is None:
         raise ValueError(f"unknown type code: {type_code}")
 

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -84,6 +84,17 @@ def read_metadata(f, records_per_chunk=1024):
     return header, metadata
 
 
+def extract_format_type(header):
+    return header.prefix_suffix_data_locators.sar_data_format_type_code
+
+
+def extract_shape(header):
+    return (
+        header.sar_related_data_in_the_record.number_of_lines_per_dataset,
+        header.sar_related_data_in_the_record.number_of_data_groups_per_line,
+    )
+
+
 dtypes = {
     "C*8": np.dtype([("real", ">f4"), ("imag", ">f4")]),
     "IU2": np.dtype(">u2"),

--- a/ceos_alos2/sar_image/signal_data.py
+++ b/ceos_alos2/sar_image/signal_data.py
@@ -67,7 +67,7 @@ signal_data_record = Struct(
         ),
         "slant_range_to_first_data_sample" / Metadata(Int32ub, units="m"),
         "data_record_window_position" / Metadata(Int32ub, units="ns"),
-        "spare" / Int32ub,
+        "blanks" / Int32ub,
     ),
     "platform_reference_information"
     / Struct(

--- a/ceos_alos2/sar_leader/__init__.py
+++ b/ceos_alos2/sar_leader/__init__.py
@@ -12,7 +12,7 @@ from ceos_alos2.sar_leader.map_projection import map_projection_record
 from ceos_alos2.sar_leader.platform_position import platform_position_record
 from ceos_alos2.sar_leader.radiometric_data import radiometric_data_record
 
-sar_leader = Struct(
+sar_leader_record = Struct(
     "file_descriptor" / file_descriptor_record,
     "dataset_summary"
     / dataset_summary_record[this.file_descriptor.dataset_summary.number_of_records],

--- a/ceos_alos2/sar_leader/map_projection.py
+++ b/ceos_alos2/sar_leader/map_projection.py
@@ -135,14 +135,14 @@ map_projection_record = Struct(
         "map_projection_to_pixels"
         / Metadata(
             Struct(
-                "A11" / AsciiFloat(16),
-                "A12" / AsciiFloat(16),
-                "A13" / AsciiFloat(16),
-                "A14" / AsciiFloat(16),
-                "A21" / AsciiFloat(16),
-                "A22" / AsciiFloat(16),
-                "A23" / AsciiFloat(16),
-                "A24" / AsciiFloat(16),
+                "A11" / AsciiFloat(20),
+                "A12" / AsciiFloat(20),
+                "A13" / AsciiFloat(20),
+                "A14" / AsciiFloat(20),
+                "A21" / AsciiFloat(20),
+                "A22" / AsciiFloat(20),
+                "A23" / AsciiFloat(20),
+                "A24" / AsciiFloat(20),
             ),
             formula=(
                 "E = A11 + A12 * L + A13 * P + A14 * L * P;"
@@ -152,14 +152,14 @@ map_projection_record = Struct(
         "pixels_to_map_projection"
         / Metadata(
             Struct(
-                "B11" / AsciiFloat(16),
-                "B12" / AsciiFloat(16),
-                "B13" / AsciiFloat(16),
-                "B14" / AsciiFloat(16),
-                "B21" / AsciiFloat(16),
-                "B22" / AsciiFloat(16),
-                "B23" / AsciiFloat(16),
-                "B24" / AsciiFloat(16),
+                "B11" / AsciiFloat(20),
+                "B12" / AsciiFloat(20),
+                "B13" / AsciiFloat(20),
+                "B14" / AsciiFloat(20),
+                "B21" / AsciiFloat(20),
+                "B22" / AsciiFloat(20),
+                "B23" / AsciiFloat(20),
+                "B24" / AsciiFloat(20),
             ),
             formula=(
                 "L = B11 + B12 * E + B13 * N + B14 * E * N;"

--- a/ceos_alos2/tests/test_array.py
+++ b/ceos_alos2/tests/test_array.py
@@ -91,3 +91,18 @@ def test_compute_selected_ranges(indexer, expected):
 
     actual = array.compute_selected_ranges(byte_ranges, indexer)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["chunksize", "expected"],
+    (
+        pytest.param(2, {0: [(0, 3), (3, 6)], 1: [(6, 9), (9, 12)], 2: [(12, 15), (15, 18)]}),
+        pytest.param(3, {0: [(0, 3), (3, 6), (6, 9)], 1: [(9, 12), (12, 15), (15, 18)]}),
+    ),
+)
+def test_groupby_chunks(chunksize, expected):
+    byte_ranges = [(0, 3), (3, 6), (6, 9), (9, 12), (12, 15), (15, 18)]
+
+    actual = array.groupby_chunks(list(enumerate(byte_ranges)), chunksize)
+
+    assert actual == expected

--- a/ceos_alos2/tests/test_array.py
+++ b/ceos_alos2/tests/test_array.py
@@ -1,0 +1,58 @@
+import pytest
+
+from ceos_alos2 import array
+
+
+@pytest.mark.parametrize(
+    ["sizes", "reference_size", "expected"],
+    (
+        pytest.param([5, 5, 5], 8, 2, id="all-equal"),
+        pytest.param([4, 9, 2], 2, 1, id="unbalanced"),
+        pytest.param([7, 6, 8], 19, 3, id="balanced"),
+    ),
+)
+def test_determine_nearest_chunksize(sizes, reference_size, expected):
+    actual = array.determine_nearest_chunksize(sizes, reference_size)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["ranges", "n_chunks", "expected"],
+    (
+        pytest.param(
+            [(0, 3), (3, 6), (6, 9), (9, 12), (12, 15), (15, 18)],
+            1,
+            {0: (0, 3), 1: (3, 6), 2: (6, 9), 3: (9, 12), 4: (12, 15), 5: (15, 18)},
+        ),
+        pytest.param(
+            [(0, 3), (3, 6), (6, 9), (9, 12), (12, 15), (15, 18)],
+            2,
+            {0: (0, 6), 1: (6, 12), 2: (12, 18)},
+        ),
+        pytest.param(
+            [(0, 3), (3, 6), (6, 9), (9, 12), (12, 15), (15, 18)], 3, {0: (0, 9), 1: (9, 18)}
+        ),
+    ),
+)
+def test_compute_chunk_ranges(ranges, n_chunks, expected):
+    actual = array.compute_chunk_ranges(ranges, n_chunks)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["ranges", "expected"],
+    (
+        pytest.param(
+            [(0, 3), (3, 9), (9, 16)],
+            [{"offset": 0, "size": 3}, {"offset": 3, "size": 6}, {"offset": 9, "size": 7}],
+        ),
+        pytest.param(
+            [(0, 3), (17, 18), (31, 100)],
+            [{"offset": 0, "size": 3}, {"offset": 17, "size": 1}, {"offset": 31, "size": 69}],
+        ),
+    ),
+)
+def test_to_offset_size(ranges, expected):
+    actual = array.to_offset_size(ranges)
+    assert actual == expected

--- a/ceos_alos2/tests/test_array.py
+++ b/ceos_alos2/tests/test_array.py
@@ -145,3 +145,12 @@ def test_relocate_ranges(chunk_info, expected):
 
     actual = array.relocate_ranges(chunk_info, byte_ranges)
     assert actual == (chunk_info, expected)
+
+
+def test_extract_ranges():
+    data = b"buwaox94ks"
+    ranges = [(1, 3), (2, 4), (3, 4), (7, 10)]
+    expected = [b"uw", b"wa", b"a", b"4ks"]
+
+    actual = array.extract_ranges(data, ranges)
+    assert actual == expected

--- a/ceos_alos2/tests/test_array.py
+++ b/ceos_alos2/tests/test_array.py
@@ -44,12 +44,16 @@ def test_compute_chunk_ranges(ranges, n_chunks, expected):
     ["ranges", "expected"],
     (
         pytest.param(
-            [(0, 3), (3, 9), (9, 16)],
-            [{"offset": 0, "size": 3}, {"offset": 3, "size": 6}, {"offset": 9, "size": 7}],
+            {0: (0, 3), 1: (3, 9), 2: (9, 16)},
+            {0: {"offset": 0, "size": 3}, 1: {"offset": 3, "size": 6}, 2: {"offset": 9, "size": 7}},
         ),
         pytest.param(
-            [(0, 3), (17, 18), (31, 100)],
-            [{"offset": 0, "size": 3}, {"offset": 17, "size": 1}, {"offset": 31, "size": 69}],
+            {0: (0, 3), 1: (17, 18), 2: (31, 100)},
+            {
+                0: {"offset": 0, "size": 3},
+                1: {"offset": 17, "size": 1},
+                2: {"offset": 31, "size": 69},
+            },
         ),
     ),
 )

--- a/ceos_alos2/tests/test_array.py
+++ b/ceos_alos2/tests/test_array.py
@@ -3,6 +3,7 @@ import io
 import fsspec
 import pytest
 from fsspec.implementations.dirfs import DirFileSystem
+from tlz.itertoolz import identity
 
 from ceos_alos2 import array
 
@@ -191,7 +192,6 @@ class TestArray:
         url = "image-file"
 
         byte_ranges = [(1, 3), (2, 4), (3, 4), (7, 10)]
-        parser = lambda x: x
 
         array.Array(
             fs=fs,
@@ -200,5 +200,5 @@ class TestArray:
             shape=shape,
             dtype=dtype,
             chunks=chunks,
-            parse_bytes=parser,
+            parse_bytes=identity,
         )

--- a/ceos_alos2/tests/test_array.py
+++ b/ceos_alos2/tests/test_array.py
@@ -56,3 +56,38 @@ def test_compute_chunk_ranges(ranges, n_chunks, expected):
 def test_to_offset_size(ranges, expected):
     actual = array.to_offset_size(ranges)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["indexer", "expected"],
+    (
+        pytest.param(2, [(2, (16, 19))], id="scalar-positive"),
+        pytest.param(-1, [(3, (22, 25))], id="scalar-negative"),
+        pytest.param([0, 2], [(0, (0, 3)), (2, (16, 19))], id="list-positive"),
+        pytest.param([0, -1], [(0, (0, 3)), (3, (22, 25))], id="list-negative"),
+        pytest.param(slice(0, 1), [(0, (0, 3))], id="slice-positive_start-positive_stop-no_step"),
+        pytest.param(
+            slice(2, None),
+            [(2, (16, 19)), (3, (22, 25))],
+            id="slice-positive_start-no_stop-no_step",
+        ),
+        pytest.param(
+            slice(None, 2), [(0, (0, 3)), (1, (5, 8))], id="slice-no_start-postive_stop-no_step"
+        ),
+        pytest.param(
+            slice(None, None, 2),
+            [(0, (0, 3)), (2, (16, 19))],
+            id="slice-no_start-no_stop-positive_step",
+        ),
+        pytest.param(
+            slice(-1, None, -2),
+            [(3, (22, 25)), (1, (5, 8))],
+            id="slice-negative_start-no_stop-negative_step",
+        ),
+    ),
+)
+def test_compute_selected_ranges(indexer, expected):
+    byte_ranges = [(0, 3), (5, 8), (16, 19), (22, 25)]
+
+    actual = array.compute_selected_ranges(byte_ranges, indexer)
+    assert actual == expected

--- a/ceos_alos2/tests/test_array.py
+++ b/ceos_alos2/tests/test_array.py
@@ -106,3 +106,42 @@ def test_groupby_chunks(chunksize, expected):
     actual = array.groupby_chunks(list(enumerate(byte_ranges)), chunksize)
 
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["selected", "expected"],
+    (
+        pytest.param(
+            {0: [(0, 5), (6, 9)], 2: [(26, 28), (28, 30)]},
+            [((0, 12), [(0, 5), (6, 9)]), ((26, 5), [(26, 28), (28, 30)])],
+        ),
+        pytest.param(
+            {1: [(17, 18), (19, 23)], 3: [(38, 41), (41, 45), (46, 48)]},
+            [((17, 8), [(17, 18), (19, 23)]), ((37, 10), [(38, 41), (41, 45), (46, 48)])],
+        ),
+    ),
+)
+def test_merge_chunk_info(selected, expected):
+    chunk_offsets = {0: (0, 12), 1: (17, 8), 2: (26, 5), 3: (37, 10)}
+    actual = array.merge_chunk_info(selected, chunk_offsets)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ["chunk_info", "expected"],
+    (
+        pytest.param(
+            {"offset": 10, "size": 200},
+            [(30, 33), (33, 36), (36, 39), (39, 42), (42, 45), (45, 48)],
+        ),
+        pytest.param(
+            {"offset": 15, "size": 200},
+            [(25, 28), (28, 31), (31, 34), (34, 37), (37, 40), (40, 43)],
+        ),
+    ),
+)
+def test_relocate_ranges(chunk_info, expected):
+    byte_ranges = [(40, 43), (43, 46), (46, 49), (49, 52), (52, 55), (55, 58)]
+
+    actual = array.relocate_ranges(chunk_info, byte_ranges)
+    assert actual == (chunk_info, expected)

--- a/ceos_alos2/tests/test_summary.py
+++ b/ceos_alos2/tests/test_summary.py
@@ -4,7 +4,7 @@ from ceos_alos2 import summary
 
 try:
     ExceptionGroup
-except NameError:
+except NameError:  # pragma: no cover
     from exceptiongroup import ExceptionGroup
 
 

--- a/ceos_alos2/volume_directory.py
+++ b/ceos_alos2/volume_directory.py
@@ -67,7 +67,7 @@ text_record = Struct(
     "blanks" / PaddedString(124),
 )
 
-volume_directory = Struct(
+volume_directory_record = Struct(
     "volume_descriptor" / volume_descriptor,
     "file_descriptors" / file_descriptor[this.volume_descriptor.number_of_file_pointer_records],
     "text_record" / text_record,

--- a/ceos_alos2/xarray.py
+++ b/ceos_alos2/xarray.py
@@ -1,0 +1,66 @@
+import datatree
+import numpy as np
+import numpy.typing
+import xarray as xr
+from xarray.backends import BackendArray
+from xarray.backends.locks import SerializableLock
+from xarray.core import indexing
+
+from ceos_alos2.array import Array
+
+
+class LazilyIndexedWrapper(BackendArray):
+    def __init__(self, array, lock):
+        self.array = array
+        self.lock = lock
+        self.shape = array.shape
+        self.dtype = array.dtype
+
+    def __getitem__(self, key: indexing.ExplicitIndexer) -> np.typing.ArrayLike:
+        return indexing.explicit_indexing_adapter(
+            key,
+            self.shape,
+            indexing.IndexingSupport.BASIC,
+            self._raw_indexing_method,
+        )
+
+    def _raw_indexing_method(self, key: tuple) -> np.typing.ArrayLike:
+        with self.lock:
+            return self.array[key]
+
+
+def to_variable(var):
+    # only need a read lock, we don't support writing
+    # TODO: do we even need the lock?
+    lock = SerializableLock()
+    if isinstance(var.data, Array):
+        data = indexing.LazilyIndexedArray(LazilyIndexedWrapper(var.data, lock))
+    else:
+        data = var.data
+
+    return xr.Variable(var.dims, data, var.attrs, encoding={"preferred_chunks": var.chunks})
+
+
+def to_dataset(group, chunks=None):
+    variables = {name: to_variable(var) for name, var in group.variables.items()}
+    backend_ds = xr.Dataset(variables, attrs=group.attrs)
+
+    return xr.backends.api._dataset_from_backend_dataset(
+        backend_ds,
+        group.url,
+        engine="ceos-alos2",
+        chunks=chunks,
+        overwrite_encoded_chunks=None,
+        inline_array=True,
+        chunked_array_type="dask",
+        from_array_kwargs={},
+        drop_variables=None,
+        cache=chunks is None,
+    )
+
+
+def to_datatree(group, chunks=None):
+    root = datatree.DataTree(data=to_dataset(group, chunks=chunks))
+    for name, subgroup in group.groups.items():
+        root[name] = to_datatree(subgroup, chunks=chunks)
+    return root

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -12,3 +12,4 @@ dependencies:
   - cytoolz
   - python-dateutil
   - construct
+  - fsspec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
   "toolz",
   "python-dateutil",
   "construct>=2.10",
+  "fsspec",
   "exceptiongroup; python_version < '3.11'",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,4 +40,4 @@ branch = true
 
 [tool.coverage.report]
 show_missing = true
-export_lines = ["pragma: no cover", "if TYPE_CHECKING"]
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,10 @@ known_first_party = "ceos_alos2"
 
 [tool.black]
 line-length = 100
+
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+export_lines = ["pragma: no cover", "if TYPE_CHECKING"]


### PR DESCRIPTION
- [x] towards #10

This adds a high-level function that handles the I/O and transforms the metadata (or will transform it, in the future). The result is then a set of internal objects that can then be transformed to a `DataTree` object.

It also adds a set of experimental functions that transform to `DataTree` (including dealing with `dask` chunks), but it currently uses internal parts of `xarray`. However, although it might be possible to replace that using public API, it might be worth pushing for `xarray`'s datatree entrypoints instead.

Very small amounts of tests, since I can't figure out how to deal with the I/O, yet.