### PR TITLE
organize the image metadata into a dataset

### DIFF
--- a/ceos_alos2/hierarchy.py
+++ b/ceos_alos2/hierarchy.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
+from numpy.typing import ArrayLike
 from tlz.dicttoolz import valfilter
 
 from ceos_alos2.array import Array
@@ -11,7 +12,7 @@ from ceos_alos2.array import Array
 @dataclass(frozen=True)
 class Variable:
     dims: str | list[str]
-    data: Array
+    data: Array | ArrayLike
     attrs: dict[str, Any]
 
     @property
@@ -28,6 +29,9 @@ class Variable:
 
     @property
     def chunks(self):
+        if not isinstance(self.data, Array):
+            return dict.fromkeys(self.dims)
+
         return dict(zip(self.dims, self.data.chunks))
 
 

--- a/ceos_alos2/io.py
+++ b/ceos_alos2/io.py
@@ -53,18 +53,18 @@ def read_image(fs, path, chunks):
     # - group attrs
     # - coords
     # - image variable attrs
-    group_attrs = sar_image.extract_attrs(header)
-    coords, var_attrs = sar_image.transform_metadata(metadata)
-    image_variable = (dims, image_data, var_attrs)
+    header_attrs = sar_image.extract_attrs(header)
+    coords, attrs = sar_image.transform_metadata(metadata)
+    image_variable = (dims, image_data, {})
 
     raw_variables = coords | {"data": image_variable}
     variables = {name: Variable(*var) for name, var in raw_variables.items()}
 
     group_name = sar_image.filename_to_groupname(path)
 
-    attrs = group_attrs | {"coordinates": list(coords)}
+    group_attrs = attrs | header_attrs | {"coordinates": list(coords)}
 
-    return Group(path=group_name, data=variables, attrs=attrs, url=None)
+    return Group(path=group_name, data=variables, attrs=group_attrs, url=None)
 
 
 def open(path, chunks=None, storage_options={}):

--- a/ceos_alos2/io.py
+++ b/ceos_alos2/io.py
@@ -62,7 +62,9 @@ def read_image(fs, path, chunks):
 
     group_name = sar_image.filename_to_groupname(path)
 
-    return Group(path=group_name, data=variables, attrs=group_attrs, url=None)
+    attrs = group_attrs | {"coordinates": list(coords)}
+
+    return Group(path=group_name, data=variables, attrs=attrs, url=None)
 
 
 def open(path, chunks=None, storage_options={}):

--- a/ceos_alos2/io.py
+++ b/ceos_alos2/io.py
@@ -5,6 +5,7 @@ from tlz.functoolz import curry
 from ceos_alos2 import sar_image
 from ceos_alos2.array import Array
 from ceos_alos2.hierarchy import Group, Variable
+from ceos_alos2.metadata import extract_attrs, transform_metadata  # noqa: F401
 
 # from ceos_alos2.sar_leader import sar_leader_record
 from ceos_alos2.summary import parse_summary

--- a/ceos_alos2/io.py
+++ b/ceos_alos2/io.py
@@ -33,7 +33,7 @@ def read_image(fs, path, chunks):
     with fs.open(path, mode="rb") as f:
         header, metadata = sar_image.read_metadata(f, chunksizes[0])
 
-    byte_ranges = [(m.data.start, m.data.stop) for m in metadata]
+    byte_ranges = [(m["data"]["start"], m["data"]["stop"]) for m in metadata]
     type_code = sar_image.extract_format_type(header)
     parser = curry(sar_image.parse_data, type_code=type_code)
 

--- a/ceos_alos2/io.py
+++ b/ceos_alos2/io.py
@@ -5,7 +5,6 @@ from tlz.functoolz import curry
 from ceos_alos2 import sar_image
 from ceos_alos2.array import Array
 from ceos_alos2.hierarchy import Group, Variable
-from ceos_alos2.metadata import extract_attrs, transform_metadata  # noqa: F401
 
 # from ceos_alos2.sar_leader import sar_leader_record
 from ceos_alos2.summary import parse_summary

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -7,6 +7,10 @@ from tlz.itertoolz import partition_all
 
 from ceos_alos2.common import record_preamble
 from ceos_alos2.sar_image.file_descriptor import file_descriptor_record
+from ceos_alos2.sar_image.metadata import (  # noqa: F401
+    extract_attrs,
+    transform_metadata,
+)
 from ceos_alos2.sar_image.processed_data import processed_data_record
 from ceos_alos2.sar_image.signal_data import signal_data_record
 

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -115,14 +115,6 @@ def extract_dtype(header):
     return dtype
 
 
-def extract_attrs(header):
-    return {}
-
-
-def transform_metadata(metadata):
-    return {}, {}
-
-
 def filename_to_groupname(path):
     from ceos_alos2.decoders import decode_filename
 

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -90,13 +90,13 @@ def read_metadata(f, records_per_chunk=1024):
 
 
 def extract_format_type(header):
-    return header.prefix_suffix_data_locators.sar_data_format_type_code
+    return header["prefix_suffix_data_locators"]["sar_data_format_type_code"]
 
 
 def extract_shape(header):
     return (
-        header.sar_related_data_in_the_record.number_of_lines_per_dataset,
-        header.sar_related_data_in_the_record.number_of_data_groups_per_line,
+        header["sar_related_data_in_the_record"]["number_of_lines_per_dataset"],
+        header["sar_related_data_in_the_record"]["number_of_data_groups_per_line"],
     )
 
 

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -13,6 +13,7 @@ from ceos_alos2.sar_image.metadata import (  # noqa: F401
 )
 from ceos_alos2.sar_image.processed_data import processed_data_record
 from ceos_alos2.sar_image.signal_data import signal_data_record
+from ceos_alos2.utils import to_dict
 
 
 def extract_record_type(preamble):
@@ -85,7 +86,7 @@ def read_metadata(f, records_per_chunk=1024):
         )
     )
 
-    return header, metadata
+    return to_dict(header), to_dict(metadata)
 
 
 def extract_format_type(header):

--- a/ceos_alos2/sar_image/metadata.py
+++ b/ceos_alos2/sar_image/metadata.py
@@ -1,12 +1,9 @@
 import numpy as np
-from rich.console import Console
 from tlz.dicttoolz import itemmap, keyfilter, keymap, merge_with, valmap
 from tlz.functoolz import compose_left, curry
 from tlz.itertoolz import first
 
 from ceos_alos2.dicttoolz import itemsplit
-
-console = Console()
 
 
 def starcall(func, args, **kwargs):

--- a/ceos_alos2/sar_image/metadata.py
+++ b/ceos_alos2/sar_image/metadata.py
@@ -1,6 +1,82 @@
+import numpy as np
+from rich.console import Console
+from tlz.dicttoolz import keyfilter, merge_with, valmap
+from tlz.functoolz import compose_left, curry
+from tlz.itertoolz import first, unique
+
+from ceos_alos2.dicttoolz import valsplit
+
+console = Console()
+
+
+def starcall(func, args, **kwargs):
+    return func(*args, **kwargs)
+
+
+def remove_nesting_layer(mapping):
+    def _remove(mapping):
+        for key, value in mapping.items():
+            if not isinstance(value, dict):
+                yield key, value
+                continue
+
+            yield from value.items()
+
+    return dict(_remove(mapping))
+
+
+def is_variable(data):
+    # "variables" are defined as one or more of:
+    # - have metadata
+    # - have multiple unique values (might have to adjust that)
+    if not isinstance(data, list) or len(data) == 0:
+        return False
+
+    first_elem = data[0]
+    if not isinstance(first_elem, tuple) and len(list(unique(data))) <= 1:
+        return False
+
+    return True
+
+
+def transform_variable(data):
+    if isinstance(data[0], tuple):
+        values, metadata_ = zip(*data)
+        metadata = metadata_[0]
+    else:
+        values = data
+        metadata = {}
+    return ("rows", np.array(values), metadata)
+
+
 def extract_attrs(header):
     return {}
 
 
 def transform_metadata(metadata):
-    return {}, {}
+    # process:
+    # - drop format metadata
+    # - remove categories
+    # - merge_with list
+    # - split into variables and attributes (TODO: criteria for variable without metadata?)
+    format_metadata = {"record_start", "preamble", "data"}
+    ignored_fields = {
+        "_io",
+        "actual_count_of_left_fill_pixels",
+        "actual_count_of_right_fill_pixels",
+        "actual_count_of_data_pixels",
+    }
+    merge = compose_left(
+        curry(map, curry(keyfilter, lambda k: k not in format_metadata)),
+        curry(map, remove_nesting_layer),
+        curry(starcall, curry(merge_with, list)),
+        curry(keyfilter, lambda k: k not in ignored_fields and not k.startswith("blanks")),
+    )
+    merged = merge(metadata)
+
+    # TODO split using known variable names instead?
+    raw_vars, raw_attrs = valsplit(is_variable, merged)
+
+    variables = valmap(transform_variable, raw_vars)
+    attrs = valmap(first, raw_attrs)
+    return variables, attrs

--- a/ceos_alos2/sar_image/metadata.py
+++ b/ceos_alos2/sar_image/metadata.py
@@ -1,7 +1,7 @@
 import numpy as np
 from rich.console import Console
 from tlz.dicttoolz import itemmap, keyfilter, keymap, merge_with, valmap
-from tlz.functoolz import compose_left, curry, juxt
+from tlz.functoolz import compose_left, curry
 from tlz.itertoolz import first
 
 from ceos_alos2.dicttoolz import itemsplit
@@ -25,12 +25,6 @@ def remove_nesting_layer(mapping):
     return dict(_remove(mapping))
 
 
-def data_astype(var, dtype):
-    dims, data, *attrs = var
-
-    return dims, data.astype(dtype), *attrs
-
-
 def transform_variable(data, dtype=None):
     if isinstance(data[0], tuple):
         values, metadata_ = zip(*data)
@@ -44,21 +38,6 @@ def transform_variable(data, dtype=None):
     else:
         data_ = np.array(values)
     return ("rows", data_, metadata)
-
-
-def postprocess_variables(variables):
-    postprocessors = {
-        "sensor_acquisition_date": curry(data_astype, dtype="datetime64[ns]"),
-    }
-
-    def apply_postprocessor(name, data):
-        postprocessor = postprocessors.get(name)
-        if postprocessor is None:
-            return data
-
-        return postprocessor(data)
-
-    return itemmap(juxt(first, curry(starcall, apply_postprocessor)), variables)
 
 
 def rename(mapping, translations):

--- a/ceos_alos2/sar_image/metadata.py
+++ b/ceos_alos2/sar_image/metadata.py
@@ -1,0 +1,6 @@
+def extract_attrs(header):
+    return {}
+
+
+def transform_metadata(metadata):
+    return {}, {}

--- a/ceos_alos2/sar_image/metadata.py
+++ b/ceos_alos2/sar_image/metadata.py
@@ -121,6 +121,8 @@ def transform_metadata(metadata):
         "platform_position_parameters_update_flag",
         "alos2_frame_number",
         "geographic_reference_parameter_update_flag",
+        "transmitted_pulse_polarization",
+        "received_pulse_polarization",
     }
     raw_vars, raw_attrs = itemsplit(lambda it: it[0] not in known_attrs, merged)
 

--- a/ceos_alos2/sar_image/metadata.py
+++ b/ceos_alos2/sar_image/metadata.py
@@ -35,6 +35,10 @@ def transform_variable(data):
     return ("rows", np.array(values), metadata)
 
 
+def rename(mapping, translations):
+    return keymap(lambda k: translations.get(k, k), mapping)
+
+
 def extract_attrs(header):
     return {}
 
@@ -59,7 +63,7 @@ def transform_metadata(metadata):
         curry(map, remove_nesting_layer),
         curry(starcall, curry(merge_with, list)),
         curry(keyfilter, lambda k: k not in ignored_fields and not k.startswith("blanks")),
-        curry(keymap, lambda k: to_rename.get(k, k)),
+        curry(rename, translations=to_rename),
     )
     merged = merge(metadata)
 

--- a/ceos_alos2/sar_image/metadata.py
+++ b/ceos_alos2/sar_image/metadata.py
@@ -110,10 +110,14 @@ def transform_metadata(metadata):
     }
     raw_vars, raw_attrs = itemsplit(lambda it: it[0] not in known_attrs, merged)
 
-    override_dtypes = dict.fromkeys(raw_vars) | {"sensor_acquisition_date": "datetime64[ns]"}
+    override_dtypes = {
+        "sensor_acquisition_date": "datetime64[ns]",
+        "sensor_acquisition_date_microseconds": "datetime64[ns]",
+    }
+    all_dtypes = dict.fromkeys(raw_vars) | keyfilter(lambda x: x in raw_vars, override_dtypes)
     variables = valmap(
         curry(starcall, transform_variable),
-        merge_with(list, raw_vars, override_dtypes),
+        merge_with(list, raw_vars, all_dtypes),
     )
     attrs = valmap(first, raw_attrs)
     return variables, attrs

--- a/ceos_alos2/utils.py
+++ b/ceos_alos2/utils.py
@@ -1,0 +1,19 @@
+import datetime
+
+from construct import EnumIntegerString
+from construct.lib.containers import ListContainer
+
+
+def to_dict(container):
+    if isinstance(container, EnumIntegerString):
+        return str(container)
+    if isinstance(container, (int, float, str, bytes, complex, datetime.datetime)):
+        return container
+    elif isinstance(container, (list, tuple)):
+        if isinstance(container, ListContainer):
+            type_ = list
+        else:
+            type_ = type(container)
+        return type_(to_dict(elem) for elem in container)
+
+    return {name: to_dict(section) for name, section in container.items() if name != "_io"}

--- a/ceos_alos2/xarray.py
+++ b/ceos_alos2/xarray.py
@@ -42,9 +42,15 @@ def to_variable(var):
     return xr.Variable(var.dims, data, var.attrs, encoding={"preferred_chunks": var.chunks})
 
 
+def decode_coords(ds):
+    coords = ds.attrs.pop("coordinates", [])
+
+    return ds.set_coords(coords)
+
+
 def to_dataset(group, chunks=None):
     variables = {name: to_variable(var) for name, var in group.variables.items()}
-    backend_ds = xr.Dataset(variables, attrs=group.attrs)
+    backend_ds = xr.Dataset(variables, attrs=group.attrs).pipe(decode_coords)
 
     return xr.backends.api._dataset_from_backend_dataset(
         backend_ds,


### PR DESCRIPTION
- [x] towards #17

There is still a lot to decide:
- is the current selection of attrs appropriate, or should any of these be variables?
- are there any 0d variables?
- what do we do with the attributes with the `start=...` metadata?

Also missing is the implementation of nested groups: some metadata in level 1.1 contains vectors, which would be best grouped together. The implementation does not deal with that, yet, but maybe it should. Otherwise we could try to remove the nesting from the `construct` definition and just deal with expanded variable names.

Either way, all of these decisions will be a different PR.