### PR TITLE
allow caching the metadata

### DIFF
--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -7,10 +7,7 @@ from tlz.itertoolz import partition_all
 
 from ceos_alos2.common import record_preamble
 from ceos_alos2.sar_image.file_descriptor import file_descriptor_record
-from ceos_alos2.sar_image.metadata import (  # noqa: F401
-    extract_attrs,
-    transform_metadata,
-)
+from ceos_alos2.sar_image.metadata import transform  # noqa: F401
 from ceos_alos2.sar_image.processed_data import processed_data_record
 from ceos_alos2.sar_image.signal_data import signal_data_record
 from ceos_alos2.utils import to_dict
@@ -86,18 +83,7 @@ def read_metadata(f, records_per_chunk=1024):
         )
     )
 
-    return to_dict(header), to_dict(metadata)
-
-
-def extract_format_type(header):
-    return header["prefix_suffix_data_locators"]["sar_data_format_type_code"]
-
-
-def extract_shape(header):
-    return (
-        header["sar_related_data_in_the_record"]["number_of_lines_per_dataset"],
-        header["sar_related_data_in_the_record"]["number_of_data_groups_per_line"],
-    )
+    return transform(to_dict(header), to_dict(metadata))
 
 
 raw_dtypes = {
@@ -109,15 +95,6 @@ dtypes = {
     "C*8": np.dtype("complex64"),
     "IU2": np.dtype("uint16"),
 }
-
-
-def extract_dtype(header):
-    type_code = extract_format_type(header)
-    dtype = dtypes.get(type_code)
-    if dtype is None:
-        raise ValueError(f"unknown type code: {type_code}")
-
-    return dtype
 
 
 def filename_to_groupname(path):

--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -6,6 +6,11 @@ from tlz.functoolz import curry
 from tlz.itertoolz import partition_all
 
 from ceos_alos2.common import record_preamble
+from ceos_alos2.sar_image.caching import (  # noqa: F401
+    CachingError,
+    create_cache,
+    read_cache,
+)
 from ceos_alos2.sar_image.file_descriptor import file_descriptor_record
 from ceos_alos2.sar_image.metadata import transform  # noqa: F401
 from ceos_alos2.sar_image.processed_data import processed_data_record

--- a/ceos_alos2/sar_image/caching.py
+++ b/ceos_alos2/sar_image/caching.py
@@ -1,0 +1,149 @@
+import hashlib
+import json
+import pathlib
+
+import numpy as np
+import platformdirs
+from tlz.dicttoolz import valmap
+
+
+class CachingError(FileNotFoundError):
+    pass
+
+
+project_name = "xarray-ceos-alos2"
+
+
+def hashsum(data, algorithm="sha256"):
+    m = hashlib.new(algorithm)
+    m.update(data.encode())
+    return m.hexdigest()
+
+
+def local_cache_location(remote_root, path):
+    subdirs, fname = path.rstrip("/", 1)
+    cache_name = f"{fname}.index"
+
+    local_root = pathlib.Path(platformdirs.user_cache_dir(project_name))
+    return local_root / hashsum(remote_root) / cache_name
+
+
+def remote_cache_location(remote_root, path):
+    return f"{path}.index"
+
+
+def encode_timedelta(obj):
+    units, _ = np.datetime_data(obj.dtype)
+
+    return obj.astype(int).tolist(), {"units": units}
+
+
+def encode_datetime(obj):
+    units, _ = np.datetime_data(obj.dtype)
+    reference = obj[0]
+
+    encoding = {"reference": str(reference), "units": units}
+    encoded = (obj - reference).astype(int).tolist()
+
+    return encoded, encoding
+
+
+def encode_array(obj):
+    def default_encode(obj):
+        return obj.tolist(), {}
+
+    encoders = {
+        "m": encode_timedelta,
+        "M": encode_datetime,
+    }
+    encoder = encoders.get(obj.dtype.kind, default_encode)
+    encoded, encoding = encoder(obj)
+
+    return {
+        "__type__": "array",
+        "dtype": str(obj.dtype),
+        "data": encoded,
+        "encoding": encoding,
+    }
+
+
+def decode_datetime(obj):
+    encoding = obj["encoding"]
+    reference = np.array(encoding["reference_date"], dtype=obj["dtype"])
+
+    timedelta = np.array(obj["data"], dtype=f"timedelta64[{encoding['units']}]")
+
+    return reference + timedelta
+
+
+def decode_array(obj):
+    def default_decode(obj):
+        return np.array(obj["data"], dtype=obj["dtype"])
+
+    type_ = obj.get("__type__")
+    if type_ == "tuple":
+        return tuple(obj["data"])
+    elif type_ != "array":
+        return obj
+
+    dtype = np.dtype(obj["dtype"])
+
+    decoders = {
+        "M": decode_datetime,
+    }
+    decoder = decoders.get(dtype.kind, default_decode)
+    decoded = decoder(obj)
+
+    return decoded
+
+
+class ArrayEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, tuple):
+            return {"__type__": "tuple", "data": list(obj)}
+        elif not isinstance(obj, np.ndarray):
+            return super().default(obj)
+
+        return encode_array(obj)
+
+
+def preprocess(data):
+    if isinstance(data, dict):
+        return valmap(preprocess, data)
+    elif isinstance(data, list):
+        return list(map(preprocess, data))
+    elif isinstance(data, tuple):
+        return {"__type__": "tuple", "data": list(preprocess(data))}
+    else:
+        return data
+
+
+def encode(data):
+    return json.dumps(preprocess(data), cls=ArrayEncoder)
+
+
+def decode(cache):
+    return json.loads(cache, object_hook=decode_array)
+
+
+def read_cache(mapper, path):
+    remote = remote_cache_location(mapper.root, path)
+    local = local_cache_location(mapper.root, path)
+
+    if local.is_file():
+        return decode(local.read_binary())
+
+    if remote in mapper:
+        return decode(mapper[remote])
+
+    raise CachingError(f"no cache found for {path}")
+
+
+def create_cache(mapper, path, data):
+    local = local_cache_location(mapper.root, path)
+
+    # ensure the directory exists
+    local.parent.mkdir(exist_ok=True, parents=True)
+
+    encoded = encode(data)
+    local.write_text(encoded)

--- a/ceos_alos2/sar_image/caching.py
+++ b/ceos_alos2/sar_image/caching.py
@@ -145,5 +145,6 @@ def create_cache(mapper, path, data):
     # ensure the directory exists
     local.parent.mkdir(exist_ok=True, parents=True)
 
-    encoded = encode(data)
+    remote_url = mapper.fs.sep.join((mapper.root, path))
+    encoded = encode({"url": remote_url} | data)
     local.write_text(encoded)

--- a/ceos_alos2/sar_image/caching.py
+++ b/ceos_alos2/sar_image/caching.py
@@ -21,7 +21,7 @@ def hashsum(data, algorithm="sha256"):
 
 
 def local_cache_location(remote_root, path):
-    subdirs, fname = path.rstrip("/", 1)
+    subdirs, fname = f"/{path}".rsplit("/", 1)
     cache_name = f"{fname}.index"
 
     local_root = pathlib.Path(platformdirs.user_cache_dir(project_name))
@@ -69,7 +69,7 @@ def encode_array(obj):
 
 def decode_datetime(obj):
     encoding = obj["encoding"]
-    reference = np.array(encoding["reference_date"], dtype=obj["dtype"])
+    reference = np.array(encoding["reference"], dtype=obj["dtype"])
 
     timedelta = np.array(obj["data"], dtype=f"timedelta64[{encoding['units']}]")
 
@@ -113,7 +113,7 @@ def preprocess(data):
     elif isinstance(data, list):
         return list(map(preprocess, data))
     elif isinstance(data, tuple):
-        return {"__type__": "tuple", "data": list(preprocess(data))}
+        return {"__type__": "tuple", "data": list(data)}
     else:
         return data
 
@@ -131,10 +131,10 @@ def read_cache(mapper, path):
     local = local_cache_location(mapper.root, path)
 
     if local.is_file():
-        return decode(local.read_binary())
+        return decode(local.read_text())
 
     if remote in mapper:
-        return decode(mapper[remote])
+        return decode(mapper[remote].decode())
 
     raise CachingError(f"no cache found for {path}")
 

--- a/ceos_alos2/xarray.py
+++ b/ceos_alos2/xarray.py
@@ -73,7 +73,7 @@ def to_datatree(group, chunks=None):
     return root
 
 
-def open_alos2(path, chunks=None, storage_options={}):
-    root = io.open(path, chunks=chunks, storage_options=storage_options)
+def open_alos2(path, chunks=None, storage_options={}, backend_options={}):
+    root = io.open(path, chunks=chunks, storage_options=storage_options, **backend_options)
 
     return to_datatree(root, chunks=chunks)


### PR DESCRIPTION
This implements a simple caching strategy: after reading the metadata, it is possible to optionally write the extracted metadata (variables, attributes, and information about the actual data) to a local cache file. For level 1.5, the result is that opening the two image files completes within ~100ms, whereas before it took roughly 14s. I'd expect even more dramatic speed-ups for level 1.1 ScanSAR, where we have 10-12 files instead of two, and which for a full read currently takes ~12 minutes.

The cache files for level 1.5 are already fairly big, so it might be necessary to use `fsspec`'s compression support (e.g. `zstd`) to compress the files.