### PR TITLE
split the chunk definition into `dask` chunks and records-per-chunk

### DIFF
--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -136,3 +136,7 @@ class Array:
     @property
     def ndim(self):
         return len(self.shape)
+
+    @property
+    def chunks(self):
+        return (self.records_per_chunk, *self.shape[1:])

--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -5,6 +5,83 @@ import numpy as np
 from tlz.itertoolz import cons, first, get, groupby, partition_all, second
 
 
+def parse_bytes(s: float | str) -> int:
+    # vendored from `dask.utils.parse_bytes` under the terms of the BSD-3 license
+    """Parse byte string to numbers
+
+    >>> from dask.utils import parse_bytes
+    >>> parse_bytes("100")
+    100
+    >>> parse_bytes("100 MB")
+    100000000
+    >>> parse_bytes("100M")
+    100000000
+    >>> parse_bytes("5kB")
+    5000
+    >>> parse_bytes("5.4 kB")
+    5400
+    >>> parse_bytes("1kiB")
+    1024
+    >>> parse_bytes("1e6")
+    1000000
+    >>> parse_bytes("1e6 kB")
+    1000000000
+    >>> parse_bytes("MB")
+    1000000
+    >>> parse_bytes(123)
+    123
+    >>> parse_bytes("5 foos")
+    Traceback (most recent call last):
+        ...
+    ValueError: Could not interpret 'foos' as a byte unit
+    """
+    if isinstance(s, (int, float)):
+        return int(s)
+    s = s.replace(" ", "")
+    if not any(char.isdigit() for char in s):
+        s = "1" + s
+
+    for i in range(len(s) - 1, -1, -1):
+        if not s[i].isalpha():
+            break
+    index = i + 1
+
+    prefix = s[:index]
+    suffix = s[index:]
+
+    try:
+        n = float(prefix)
+    except ValueError as e:
+        raise ValueError("Could not interpret '%s' as a number" % prefix) from e
+
+    try:
+        multiplier = byte_sizes[suffix.lower()]
+    except KeyError as e:
+        raise ValueError("Could not interpret '%s' as a byte unit" % suffix) from e
+
+    result = n * multiplier
+    return int(result)
+
+
+byte_sizes = {
+    "kB": 10**3,
+    "MB": 10**6,
+    "GB": 10**9,
+    "TB": 10**12,
+    "PB": 10**15,
+    "KiB": 2**10,
+    "MiB": 2**20,
+    "GiB": 2**30,
+    "TiB": 2**40,
+    "PiB": 2**50,
+    "B": 1,
+    "": 1,
+}
+byte_sizes = {k.lower(): v for k, v in byte_sizes.items()}
+byte_sizes.update({k[0]: v for k, v in byte_sizes.items() if k and "i" not in k})
+byte_sizes.update({k[:-1]: v for k, v in byte_sizes.items() if k and "i" in k})
+
+
 def normalize_chunksize(chunksize, dim_size):
     if chunksize in (None, -1) or chunksize > dim_size:
         return dim_size
@@ -105,11 +182,13 @@ class Array:
         possible_chunksizes = np.cumsum(sizes)
         if self.records_per_chunk is None:
             self.records_per_chunk = 1024
-        elif self.records_per_chunk == "auto":
-            reference_size = 100 * 2**20
-            self.records_per_chunk = determine_nearest_chunksize(
-                possible_chunksizes, reference_size
-            )
+        elif isinstance(self.records_per_chunk, str):
+            if self.records_per_chunk == "auto":
+                size = 100 * 2**20
+            else:
+                size = parse_bytes(self.records_per_chunk)
+
+            self.records_per_chunk = determine_nearest_chunksize(possible_chunksizes, size)
         else:
             self.records_per_chunk = normalize_chunksize(self.records_per_chunk, self.shape[0])
         self.chunk_offsets = compute_chunk_offsets(self.byte_ranges, self.records_per_chunk)

--- a/ceos_alos2/array.py
+++ b/ceos_alos2/array.py
@@ -179,7 +179,6 @@ class Array:
 
     def __post_init__(self):
         sizes = np.array([stop - start for start, stop in self.byte_ranges])
-        possible_chunksizes = np.cumsum(sizes)
         if self.records_per_chunk is None:
             self.records_per_chunk = 1024
         elif isinstance(self.records_per_chunk, str):
@@ -188,7 +187,7 @@ class Array:
             else:
                 size = parse_bytes(self.records_per_chunk)
 
-            self.records_per_chunk = determine_nearest_chunksize(possible_chunksizes, size)
+            self.records_per_chunk = determine_nearest_chunksize(sizes, size)
         else:
             self.records_per_chunk = normalize_chunksize(self.records_per_chunk, self.shape[0])
         self.chunk_offsets = compute_chunk_offsets(self.byte_ranges, self.records_per_chunk)

--- a/ceos_alos2/hierarchy.py
+++ b/ceos_alos2/hierarchy.py
@@ -15,6 +15,11 @@ class Variable:
     data: Array | ArrayLike
     attrs: dict[str, Any]
 
+    def __post_init__(self):
+        if isinstance(self.dims, str):
+            # normalize, need the hack
+            super().__setattr__("dims", [self.dims])
+
     @property
     def ndim(self):
         return self.data.ndim

--- a/ceos_alos2/hierarchy.py
+++ b/ceos_alos2/hierarchy.py
@@ -39,6 +39,10 @@ class Variable:
 
         return dict(zip(self.dims, self.data.chunks))
 
+    @property
+    def sizes(self):
+        return dict(zip(self.dims, self.data.shape))
+
 
 @dataclass
 class Group(Mapping):

--- a/ceos_alos2/tests/test_array.py
+++ b/ceos_alos2/tests/test_array.py
@@ -186,8 +186,8 @@ def test_read_chunk(offset, size):
 class TestArray:
     @pytest.mark.parametrize("shape", ((10, 10), (20, 10), (10, 20), (20, 20)))
     @pytest.mark.parametrize("dtype", ("uint16", "complex64"))
-    @pytest.mark.parametrize("chunks", (None, "auto", (-1, 10), (10, -1), (10, 10)))
-    def test_init(self, shape, dtype, chunks):
+    @pytest.mark.parametrize("chunksize", (None, "auto", -1, 10))
+    def test_init(self, shape, dtype, chunksize):
         fs = DirFileSystem(fs=fsspec.filesystem("memory"), path="/")
         url = "image-file"
 
@@ -199,6 +199,6 @@ class TestArray:
             byte_ranges=byte_ranges,
             shape=shape,
             dtype=dtype,
-            chunks=chunks,
+            records_per_chunk=chunksize,
             parse_bytes=identity,
         )

--- a/ceos_alos2/xarray.py
+++ b/ceos_alos2/xarray.py
@@ -30,6 +30,20 @@ class LazilyIndexedWrapper(BackendArray):
             return self.array[key]
 
 
+def extract_encoding(var):
+    chunks = var.chunks
+
+    if all(c is None for c in chunks.values()):
+        return {}
+
+    normalized_chunks = {
+        dim: chunksize if chunksize not in (None, -1) else var.sizes[dim]
+        for dim, chunksize in chunks.items()
+    }
+
+    return {"preferred_chunksizes": normalized_chunks}
+
+
 def to_variable(var):
     # only need a read lock, we don't support writing
     # TODO: do we even need the lock?
@@ -39,7 +53,7 @@ def to_variable(var):
     else:
         data = var.data
 
-    return xr.Variable(var.dims, data, var.attrs, encoding={"preferred_chunks": var.chunks})
+    return xr.Variable(var.dims, data, var.attrs, encoding=extract_encoding(var))
 
 
 def decode_coords(ds):

--- a/ceos_alos2/xarray.py
+++ b/ceos_alos2/xarray.py
@@ -74,6 +74,6 @@ def to_datatree(group, chunks=None):
 
 
 def open_alos2(path, chunks=None, storage_options={}, backend_options={}):
-    root = io.open(path, chunks=chunks, storage_options=storage_options, **backend_options)
+    root = io.open(path, storage_options=storage_options, **backend_options)
 
     return to_datatree(root, chunks=chunks)

--- a/licenses/DASK
+++ b/licenses/DASK
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2014, Anaconda, Inc. and contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
- [x] follow-up to #16

These are different concepts: records-per-chunk defines the size of individual requests, while `dask` chunks are the size of the computational unit.

By separating both, we could potentially combine multiple record groups into a single `dask` chunk.