### PR TITLE
tests for the caching mechanism

### DIFF
--- a/ceos_alos2/sar_image/caching/__init__.py
+++ b/ceos_alos2/sar_image/caching/__init__.py
@@ -1,6 +1,6 @@
 import json
 
-from ceos_alos2.sar_image.caching.decoders import decode_hierarchy, decode_objects
+from ceos_alos2.sar_image.caching.decoders import decode_hierarchy, postprocess
 from ceos_alos2.sar_image.caching.encoders import encode_hierarchy, preprocess
 from ceos_alos2.sar_image.caching.path import (
     local_cache_location,
@@ -19,7 +19,7 @@ def encode(obj):
 
 
 def decode(cache, records_per_chunk):
-    partially_decoded = json.loads(cache, object_hook=decode_objects)
+    partially_decoded = json.loads(cache, object_hook=postprocess)
 
     return decode_hierarchy(partially_decoded, records_per_chunk=records_per_chunk)
 

--- a/ceos_alos2/sar_image/caching/decoders.py
+++ b/ceos_alos2/sar_image/caching/decoders.py
@@ -8,6 +8,13 @@ from ceos_alos2.hierarchy import Group, Variable
 from ceos_alos2.sar_image.io import parse_data
 
 
+def postprocess(obj):
+    if obj.get("__type__") == "tuple":
+        return tuple(obj["data"])
+
+    return obj
+
+
 def decode_datetime(obj):
     encoding = obj["encoding"]
     reference = np.array(encoding["reference"], dtype=obj["dtype"])

--- a/ceos_alos2/sar_image/caching/decoders.py
+++ b/ceos_alos2/sar_image/caching/decoders.py
@@ -5,7 +5,6 @@ from tlz.functoolz import curry
 
 from ceos_alos2.array import Array
 from ceos_alos2.hierarchy import Group, Variable
-from ceos_alos2.sar_image.io import parse_data
 
 
 def postprocess(obj):
@@ -55,7 +54,7 @@ def decode_array(encoded, records_per_chunk):
 
         fs = DirFileSystem(fs=mapper.fs, path=mapper.root)
 
-    parser = curry(parse_data, type_code=encoded["type_code"])
+    type_code = encoded["type_code"]
     url = encoded["url"]
     shape = encoded["shape"]
     dtype = encoded["dtype"]
@@ -66,7 +65,7 @@ def decode_array(encoded, records_per_chunk):
         byte_ranges=byte_ranges,
         shape=shape,
         dtype=dtype,
-        parse_bytes=parser,
+        type_code=type_code,
         records_per_chunk=records_per_chunk,
     )
 

--- a/ceos_alos2/sar_image/caching/encoders.py
+++ b/ceos_alos2/sar_image/caching/encoders.py
@@ -21,7 +21,18 @@ def encode_datetime(obj):
     return encoded, encoding
 
 
-def encode_arraylike(obj):
+def encode_array(obj):
+    if isinstance(obj, Array):
+        return {
+            "__type__": "backend_array",
+            "root": obj.fs.path,
+            "url": obj.url,
+            "shape": obj.shape,
+            "dtype": str(obj.dtype),
+            "byte_ranges": obj.byte_ranges,
+            "type_code": obj.parse_bytes.keywords["type_code"],
+        }
+
     def default_encode(obj):
         return obj.tolist(), {}
 
@@ -37,21 +48,6 @@ def encode_arraylike(obj):
         "dtype": str(obj.dtype),
         "data": encoded,
         "encoding": encoding,
-    }
-
-
-def encode_array(obj):
-    if not isinstance(obj, Array):
-        return encode_arraylike(obj)
-
-    return {
-        "__type__": "record_array",
-        "root": obj.fs.path,
-        "url": obj.url,
-        "shape": obj.shape,
-        "dtype": str(obj.dtype),
-        "byte_ranges": obj.byte_ranges,
-        "type_code": obj.parse_bytes.keywords["type_code"],
     }
 
 

--- a/ceos_alos2/sar_image/caching/encoders.py
+++ b/ceos_alos2/sar_image/caching/encoders.py
@@ -66,10 +66,8 @@ def encode_group(group):
     def encode_entry(obj):
         if isinstance(obj, Group):
             return encode_group(obj)
-        elif isinstance(obj, Variable):
-            return encode_variable(obj)
         else:
-            return ValueError(f"unknown type: {type(obj)}")
+            return encode_variable(obj)
 
     encoded_data = valmap(encode_entry, group.data)
 

--- a/ceos_alos2/sar_image/caching/encoders.py
+++ b/ceos_alos2/sar_image/caching/encoders.py
@@ -30,7 +30,7 @@ def encode_array(obj):
             "shape": obj.shape,
             "dtype": str(obj.dtype),
             "byte_ranges": obj.byte_ranges,
-            "type_code": obj.parse_bytes.keywords["type_code"],
+            "type_code": obj.type_code,
         }
 
     def default_encode(obj):

--- a/ceos_alos2/sar_image/caching/path.py
+++ b/ceos_alos2/sar_image/caching/path.py
@@ -1,9 +1,9 @@
 import hashlib
-import pathlib
 
 import platformdirs
 
 project_name = "xarray-ceos-alos2"
+cache_root = platformdirs.user_cache_path(project_name)
 
 
 def hashsum(data, algorithm="sha256"):
@@ -13,11 +13,10 @@ def hashsum(data, algorithm="sha256"):
 
 
 def local_cache_location(remote_root, path):
-    subdirs, fname = f"/{path}".rsplit("/", 1)
+    _, fname = f"/{path}".rsplit("/", 1)
     cache_name = f"{fname}.index"
 
-    local_root = pathlib.Path(platformdirs.user_cache_dir(project_name))
-    return local_root / hashsum(remote_root) / cache_name
+    return cache_root / hashsum(remote_root) / cache_name
 
 
 def remote_cache_location(remote_root, path):

--- a/ceos_alos2/sar_image/io.py
+++ b/ceos_alos2/sar_image/io.py
@@ -1,14 +1,11 @@
 import itertools
 import math
 
-import numpy as np
-from tlz.functoolz import curry
 from tlz.itertoolz import concat
 
 from ceos_alos2.array import Array
 from ceos_alos2.common import record_preamble
 from ceos_alos2.sar_image.file_descriptor import file_descriptor_record
-from ceos_alos2.sar_image.metadata import raw_dtypes
 from ceos_alos2.sar_image.processed_data import processed_data_record
 from ceos_alos2.sar_image.signal_data import signal_data_record
 from ceos_alos2.utils import to_dict
@@ -19,27 +16,14 @@ record_types = {
 }
 
 
-def parse_data(content, type_code):
-    dtype = raw_dtypes.get(type_code)
-    if dtype is None:
-        raise ValueError(f"unknown type code: {type_code}")
-
-    raw = np.frombuffer(content, dtype)
-    if type_code == "C*8":
-        return raw["real"] + 1j * raw["imag"]
-    return raw
-
-
 def create_array(fs, path, byte_ranges, shape, dtype, type_code, records_per_chunk):
-    parser = curry(parse_data, type_code=type_code)
-
     return Array(
         fs=fs,
         url=path,
         byte_ranges=byte_ranges,
         shape=shape,
         dtype=dtype,
-        parse_bytes=parser,
+        type_code=type_code,
         records_per_chunk=records_per_chunk,
     )
 

--- a/ceos_alos2/sar_image/metadata.py
+++ b/ceos_alos2/sar_image/metadata.py
@@ -172,11 +172,6 @@ def metadata_to_groups(metadata):
     return Group(path="", url=None, data=processed, attrs=attrs)
 
 
-raw_dtypes = {
-    "C*8": np.dtype([("real", ">f4"), ("imag", ">f4")]),
-    "IU2": np.dtype(">u2"),
-}
-
 dtypes = {
     "C*8": np.dtype("complex64"),
     "IU2": np.dtype("uint16"),

--- a/ceos_alos2/testing.py
+++ b/ceos_alos2/testing.py
@@ -149,12 +149,15 @@ def diff_array(a, b):
     sections = []
     if a.fs != b.fs:
         lines = ["Differing filesystem:"]
-        if a.fs.protocol != b.fs.protocol:
-            lines.append(f"  L protocol  {a.fs.protocol}")
-            lines.append(f"  R protocol  {b.fs.protocol}")
+        # fs.protocol is always `dir`, so we have to check the wrapped fs
+        if a.fs.fs.protocol != b.fs.fs.protocol:
+            lines.append(f"  L protocol  {a.fs.fs.protocol}")
+            lines.append(f"  R protocol  {b.fs.fs.protocol}")
         if a.fs.path != b.fs.path:
             lines.append(f"  L path  {a.fs.path}")
             lines.append(f"  R path  {b.fs.path}")
+        if len(lines) == 1:
+            lines.append("  (unknown differences)")
         sections.append(newline.join(lines))
     if a.url != b.url:
         lines = [

--- a/ceos_alos2/testing.py
+++ b/ceos_alos2/testing.py
@@ -183,11 +183,11 @@ def diff_array(a, b):
             f"  {a.dtype} != {b.dtype}",
         ]
         sections.append(newline.join(lines))
-    if a.parse_bytes != b.parse_bytes:
+    if a.type_code != b.type_code:
         lines = [
-            "Differing byte parser:",
-            f"  L type_code  {a.parse_bytes.parameters['type_code']}",
-            f"  R type_code  {b.parse_bytes.parameters['type_code']}",
+            "Differing type code:",
+            f"  L type_code  {a.type_code}",
+            f"  R type_code  {b.type_code}",
         ]
         sections.append(newline.join(lines))
     if a.records_per_chunk != b.records_per_chunk:

--- a/ceos_alos2/tests/test_caching.py
+++ b/ceos_alos2/tests/test_caching.py
@@ -314,3 +314,29 @@ class TestEncoders:
         actual = caching.encoders.encode_group(group)
 
         assert actual == expected
+
+    @pytest.mark.parametrize(
+        ["obj", "expected"],
+        (
+            pytest.param(
+                Group(path=None, url=None, data={}, attrs={"a": 1}),
+                {"__type__": "group", "path": "/", "url": None, "data": {}, "attrs": {"a": 1}},
+                id="group",
+            ),
+            pytest.param(
+                Variable("x", np.array([1, 2], dtype="int64"), {}),
+                {
+                    "__type__": "variable",
+                    "dims": ["x"],
+                    "data": {"__type__": "array", "data": [1, 2], "dtype": "int32", "encoding": {}},
+                    "attrs": {},
+                },
+                id="variable",
+            ),
+            pytest.param(1, 1, id="other"),
+        ),
+    )
+    def test_encode_hierarchy(self, obj, expected):
+        actual = caching.encoders.encode_hierarchy(obj)
+
+        assert actual == expected

--- a/ceos_alos2/tests/test_caching.py
+++ b/ceos_alos2/tests/test_caching.py
@@ -367,3 +367,35 @@ class TestEncoders:
         actual = caching.encoders.preprocess(data)
 
         assert actual == expected
+
+
+class TestDecoders:
+    @pytest.mark.parametrize(
+        ["data", "expected"],
+        (
+            pytest.param(
+                {
+                    "__type__": "array",
+                    "data": [0, 3600],
+                    "dtype": "datetime64[s]",
+                    "encoding": {"units": "s", "reference": "2020-01-01T00:00:00"},
+                },
+                np.array(["2020-01-01 00:00:00", "2020-01-01 01:00:00"], dtype="datetime64[s]"),
+                id="datetime-s",
+            ),
+            pytest.param(
+                {
+                    "__type__": "array",
+                    "data": [0, 60000],
+                    "dtype": "datetime64[ms]",
+                    "encoding": {"units": "ms", "reference": "2021-01-01T00:00:00"},
+                },
+                np.array(["2021-01-01 00:00:00", "2021-01-01 00:01:00"], dtype="datetime64[ms]"),
+                id="datetime-ms",
+            ),
+        ),
+    )
+    def test_decode_datetime(self, data, expected):
+        actual = caching.decoders.decode_datetime(data)
+
+        np.testing.assert_equal(actual, expected)

--- a/ceos_alos2/tests/test_caching.py
+++ b/ceos_alos2/tests/test_caching.py
@@ -373,6 +373,24 @@ class TestDecoders:
     @pytest.mark.parametrize(
         ["data", "expected"],
         (
+            pytest.param({}, {}, id="empty"),
+            pytest.param({"a": 1}, {"a": 1}, id="default"),
+            pytest.param({"__type__": "tuple", "data": [2, 3]}, (2, 3), id="tuple"),
+            pytest.param(
+                {"__type__": "array", "data": [1, 2], "dtype": "int8", "encoding": {}},
+                {"__type__": "array", "data": [1, 2], "dtype": "int8", "encoding": {}},
+                id="array",
+            ),
+        ),
+    )
+    def test_postprocess(self, data, expected):
+        actual = caching.decoders.postprocess(data)
+
+        assert actual == expected
+
+    @pytest.mark.parametrize(
+        ["data", "expected"],
+        (
             pytest.param(
                 {
                     "__type__": "array",

--- a/ceos_alos2/tests/test_caching.py
+++ b/ceos_alos2/tests/test_caching.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import pytest
+
+from ceos_alos2.sar_image import caching
+from ceos_alos2.sar_image.caching.path import project_name
+
+
+def test_hashsum():
+    # no need to verify the external library extensively
+    data = "ddeeaaddbbeeeeff"
+    expected = "b8be84665c5cd09ec19677ce9714bcd987422de886ac2e8432a3e2311b5f0cde"
+
+    actual = caching.path.hashsum(data)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "cache_dir",
+    [
+        Path("/path/to/cache1") / project_name,
+        Path("/path/to/cache2") / project_name,
+    ],
+)
+@pytest.mark.parametrize(
+    ["remote_root", "path", "expected"],
+    (
+        pytest.param(
+            "http://127.0.0.1/path/to/data",
+            "image1",
+            Path("c9db4f27e586452c6517524752dc472863ee42230ba98e83a346b8da94a33235/image1.index"),
+        ),
+        pytest.param(
+            "s3://bucket/path/to/data",
+            "image1",
+            Path("04391cfcf37045b78e7b4793392821b5b4c84591edfcb475954130eb34b87366/image1.index"),
+        ),
+        pytest.param(
+            "file:///path/to/data",
+            "image1",
+            Path("9506f2b2ddfa8498bc4c1d3cc50d02ee5f799f6716710ff4dd31a9f6e41eac45/image1.index"),
+        ),
+        pytest.param(
+            "/path/to/data",
+            "image2",
+            Path("7b405676e8ed8556a3f4f98f4dc5b6df940f3a5ce48674046eebda551e335b37/image2.index"),
+        ),
+    ),
+)
+def test_local_cache_location(monkeypatch, cache_dir, remote_root, path, expected):
+    monkeypatch.setattr(caching.path, "cache_root", cache_dir)
+
+    actual = caching.path.local_cache_location(remote_root, path)
+
+    assert cache_dir in actual.parents
+    assert actual.relative_to(cache_dir) == expected
+
+
+@pytest.mark.parametrize(
+    "remote_root", ("http://127.0.0.1/path/to/data", "s3://bucket/path/to/data")
+)
+@pytest.mark.parametrize(
+    ["path", "expected"],
+    (
+        ("image1", "image1.index"),
+        ("image7", "image7.index"),
+    ),
+)
+def test_remote_cache_location(remote_root, path, expected):
+    actual = caching.path.remote_cache_location(remote_root, path)
+
+    assert actual == expected

--- a/ceos_alos2/tests/test_caching.py
+++ b/ceos_alos2/tests/test_caching.py
@@ -328,7 +328,7 @@ class TestEncoders:
                 {
                     "__type__": "variable",
                     "dims": ["x"],
-                    "data": {"__type__": "array", "data": [1, 2], "dtype": "int32", "encoding": {}},
+                    "data": {"__type__": "array", "data": [1, 2], "dtype": "int64", "encoding": {}},
                     "attrs": {},
                 },
                 id="variable",

--- a/ceos_alos2/tests/test_caching.py
+++ b/ceos_alos2/tests/test_caching.py
@@ -340,3 +340,30 @@ class TestEncoders:
         actual = caching.encoders.encode_hierarchy(obj)
 
         assert actual == expected
+
+    @pytest.mark.parametrize(
+        ["data", "expected"],
+        (
+            pytest.param(1, 1, id="other"),
+            pytest.param((2, 3), {"__type__": "tuple", "data": [2, 3]}, id="tuple"),
+            pytest.param([2, 3], [2, 3], id="list"),
+            pytest.param({"a": 1, "b": 2}, {"a": 1, "b": 2}, id="dict"),
+            pytest.param(
+                ({"a": 1}, 2), {"__type__": "tuple", "data": [{"a": 1}, 2]}, id="nested_tuple"
+            ),
+            pytest.param(
+                [(2, 3), (3, 4)],
+                [{"__type__": "tuple", "data": [2, 3]}, {"__type__": "tuple", "data": [3, 4]}],
+                id="nested_list",
+            ),
+            pytest.param(
+                {"a": (2, 3), "b": [{"c": 1}]},
+                {"a": {"__type__": "tuple", "data": [2, 3]}, "b": [{"c": 1}]},
+                id="nested_dict",
+            ),
+        ),
+    )
+    def test_preprocess(self, data, expected):
+        actual = caching.encoders.preprocess(data)
+
+        assert actual == expected

--- a/ceos_alos2/tests/utils.py
+++ b/ceos_alos2/tests/utils.py
@@ -1,14 +1,9 @@
 import fsspec
-from tlz.functoolz import curry
 
 from ceos_alos2.array import Array
 
 
-def parser(data, type_code):
-    return data
-
-
-def create_dummy_array(shape=(4, 3), dtype="int16"):
+def create_dummy_array(shape=(4, 3), dtype="int16", records_per_chunk=2, type_code="IU2"):
     byte_ranges = [(x * 10 + 5, (x + 1) * 10) for x in range(shape[0])]
 
     fs = fsspec.filesystem("memory")
@@ -20,6 +15,6 @@ def create_dummy_array(shape=(4, 3), dtype="int16"):
         byte_ranges=byte_ranges,
         shape=shape,
         dtype=dtype,
-        parse_bytes=curry(parser, type_code="IU2"),
-        records_per_chunk=2,
+        type_code=type_code,
+        records_per_chunk=records_per_chunk,
     )


### PR DESCRIPTION
- [x] towards #25

In order to write tests for the caching mechanism, I finally decided to move the definition of `parse_data` to `ceos_alos2.array`. This means that the `Array` object can now take the `type_code` instead of the curried `parse_data`, which makes serializing and deserializing a lot easier. However, this most likely also breaks some of the (currently untested) code, so this is a reminder to myself to make sure to fix that.