### PR TITLE
organize the metadata in the map projection record

### DIFF
--- a/ceos_alos2/sar_leader/map_projection.py
+++ b/ceos_alos2/sar_leader/map_projection.py
@@ -145,9 +145,13 @@ map_projection_record = Struct(
                 "A24" / AsciiFloat(20),
             ),
             formula=(
-                "E = A11 + A12 * L + A13 * P + A14 * L * P;"
-                " N = A21 + A22 * L + A23 * P + A24 * L * P"
+                "E = A11 + A12 * R + A13 * C + A14 * R * C;"
+                " N = A21 + A22 * R + A23 * C + A24 * R * C"
             ),
+            E="easting",
+            N="northing",
+            R="row (1-based)",
+            C="column (1-based)",
         ),
         "pixels_to_map_projection"
         / Metadata(
@@ -162,9 +166,13 @@ map_projection_record = Struct(
                 "B24" / AsciiFloat(20),
             ),
             formula=(
-                "L = B11 + B12 * E + B13 * N + B14 * E * N;"
-                " P = B21 + B22 * E + B23 * N + B24 * E * N",
+                "R = B11 + B12 * E + B13 * N + B14 * E * N;"
+                " C = B21 + B22 * E + B23 * N + B24 * E * N"
             ),
+            E="easting",
+            N="northing",
+            R="row (1-based)",
+            C="column (1-based)",
         ),
     ),
     "blanks" / PaddedString(36),

--- a/ceos_alos2/sar_leader/map_projection.py
+++ b/ceos_alos2/sar_leader/map_projection.py
@@ -49,7 +49,7 @@ map_projection_record = Struct(
         ),
         "scale_factor" / AsciiFloat(16),
     ),
-    "map_projection_description" / PaddedString(32),
+    "map_projection_designator" / PaddedString(32),
     "utm_projection"
     / Struct(
         "type" / PaddedString(32),
@@ -110,14 +110,14 @@ map_projection_record = Struct(
     / Struct(
         "projected"
         / Struct(
-            "top_left_corder" / projected_map_point,
+            "top_left_corner" / projected_map_point,
             "top_right_corner" / projected_map_point,
             "bottom_right_corner" / projected_map_point,
             "bottom_left_corner" / projected_map_point,
         ),
         "geographic"
         / Struct(
-            "top_left_corder" / geographic_map_point,
+            "top_left_corner" / geographic_map_point,
             "top_right_corner" / geographic_map_point,
             "bottom_right_corner" / geographic_map_point,
             "bottom_left_corner" / geographic_map_point,

--- a/ceos_alos2/transformers.py
+++ b/ceos_alos2/transformers.py
@@ -11,7 +11,25 @@ def normalize_datetime(string):
 
 
 def remove_spares(mapping):
-    return keyfilter(lambda k: not k.startswith("spare") or not k[5:].isdigit(), mapping)
+    def predicate(k):
+        if not k.startswith(("spare", "blanks")):
+            return True
+
+        k_ = k.removeprefix("spare").removeprefix("blanks")
+
+        return k_ and not k_.isdigit()
+
+    def _recursive(value):
+        if isinstance(value, list):
+            return list(map(remove_spares, value))
+        elif isinstance(value, dict):
+            filtered = keyfilter(predicate, value)
+
+            return valmap(_recursive, filtered)
+        else:
+            return value
+
+    return _recursive(mapping)
 
 
 def item_type(item):

--- a/ceos_alos2/transformers.py
+++ b/ceos_alos2/transformers.py
@@ -43,9 +43,13 @@ def item_type(item):
 
 
 def as_variable(value):
-    data, attrs = value
+    if len(value) == 2:
+        data, attrs = value
+        dims = ()
+    else:
+        dims, data, attrs = value
 
-    return Variable((), data, attrs)
+    return Variable(dims, data, attrs)
 
 
 def as_group(mapping):


### PR DESCRIPTION
- [x] towards #29

There's quite a few things to do here: filtering out the unused projection records and restructuring the corner points / inexact conversion coefficients.

No tests, yet.