### PR TITLE
organize the metadata in the data quality summary record

### DIFF
--- a/ceos_alos2/sar_leader/attitude.py
+++ b/ceos_alos2/sar_leader/attitude.py
@@ -1,13 +1,13 @@
 import numpy as np
 from construct import Struct, this
-from tlz.dicttoolz import merge_with, valmap
+from tlz.dicttoolz import valmap
 from tlz.functoolz import curry, pipe
 from tlz.itertoolz import cons, get
 
 from ceos_alos2.common import record_preamble
 from ceos_alos2.datatypes import AsciiFloat, AsciiInteger, Metadata, PaddedString
 from ceos_alos2.dicttoolz import apply_to_items, copy_items, dissoc
-from ceos_alos2.transformers import as_group, separate_attrs
+from ceos_alos2.transformers import as_group, separate_attrs, transform_nested
 
 attitude_point = Struct(
     "time"
@@ -50,20 +50,6 @@ def transform_time(mapping):
 
     return (transformed["day_of_year"] + transformed["millisecond_of_day"]).astype(
         "timedelta64[ns]"
-    )
-
-
-def transform_nested(mapping):
-    def _transform(value):
-        if not isinstance(value, list) or not value or not isinstance(value[0], dict):
-            return value
-
-        return merge_with(list, *value)
-
-    return pipe(
-        mapping,
-        curry(_transform),
-        curry(valmap, _transform),
     )
 
 

--- a/ceos_alos2/sar_leader/data_quality_summary.py
+++ b/ceos_alos2/sar_leader/data_quality_summary.py
@@ -84,7 +84,7 @@ def transform_relative(mapping, key):
 
 def transform_summary(mapping):
     ignored = ["preamble", "record_number"]
-    translations = {
+    transformers = {
         "relative_radiometric_quality": curry(
             transform_relative, key="nominal_relative_radiometric_calibration_uncertainty"
         ),
@@ -97,7 +97,7 @@ def transform_summary(mapping):
         mapping,
         curry(remove_spares),
         curry(dissoc, ignored),
-        curry(apply_to_items, translations),
+        curry(apply_to_items, transformers),
         curry(as_group),
     )
 

--- a/ceos_alos2/sar_leader/data_quality_summary.py
+++ b/ceos_alos2/sar_leader/data_quality_summary.py
@@ -1,7 +1,17 @@
 from construct import Struct, this
+from tlz.dicttoolz import valmap
+from tlz.functoolz import compose_left, curry, pipe
+from tlz.itertoolz import cons, get
 
 from ceos_alos2.common import record_preamble
 from ceos_alos2.datatypes import AsciiFloat, AsciiInteger, Metadata, PaddedString
+from ceos_alos2.dicttoolz import apply_to_items, dissoc
+from ceos_alos2.transformers import (
+    as_group,
+    remove_spares,
+    separate_attrs,
+    transform_nested,
+)
 
 calibration_uncertainty = Struct(
     "magnitude" / Metadata(AsciiFloat(16), units="dB"),
@@ -38,7 +48,7 @@ data_quality_summary_record = Struct(
         / calibration_uncertainty[this._.number_of_channels],
         "blanks" / PaddedString(512 - this._.number_of_channels * 32),
     ),
-    "absolute_geometric_data_quality"
+    "absolute_geometric_quality"
     / Struct(
         "absolute_location_error"
         / Struct(
@@ -53,11 +63,42 @@ data_quality_summary_record = Struct(
         "geometric_distortion_skew" / AsciiFloat(16),
         "scene_orientation_error" / AsciiFloat(16),
     ),
-    "relative_geometric_data_quality"
+    "relative_geometric_quality"
     / Struct(
         # TODO: does that actually make sense?
-        "relative_misregistration_error" / misregistration_error[8],
-        # TODO: this is 16 more than stated in the reference... is this on us or on JAXA?
-        "blanks" / PaddedString(534),
+        "relative_misregistration_error" / misregistration_error[this._.number_of_channels],
+        # TODO: 534 is 16 more than stated in the reference... is this on us or on JAXA?
+        "blanks" / PaddedString(534 + (8 - this._.number_of_channels) * 32),
     ),
 )
+
+
+def transform_relative(mapping, key):
+    return pipe(
+        mapping,
+        curry(get, key),
+        curry(transform_nested),
+        curry(valmap, compose_left(separate_attrs, curry(cons, "channel"), tuple)),
+    )
+
+
+def transform_summary(mapping):
+    ignored = ["preamble", "record_number"]
+    translations = {
+        "relative_radiometric_quality": curry(
+            transform_relative, key="nominal_relative_radiometric_calibration_uncertainty"
+        ),
+        "relative_geometric_quality": curry(
+            transform_relative, key="relative_misregistration_error"
+        ),
+    }
+
+    result = pipe(
+        mapping,
+        curry(remove_spares),
+        curry(dissoc, ignored),
+        curry(apply_to_items, translations),
+        curry(as_group),
+    )
+
+    return result

--- a/ceos_alos2/tests/test_sar_leader.py
+++ b/ceos_alos2/tests/test_sar_leader.py
@@ -643,29 +643,6 @@ class TestAttitude:
         np.testing.assert_equal(actual, expected)
 
     @pytest.mark.parametrize(
-        ["mapping", "expected"],
-        (
-            pytest.param(
-                [{"a": {"b": 1, "c": 2}}, {"a": {"b": 2, "c": 3}}, {"a": {"b": 3, "c": 4}}],
-                {"a": {"b": [1, 2, 3], "c": [2, 3, 4]}},
-            ),
-            pytest.param(
-                [
-                    {"a": {"b": 1, "c": 2}, "d": {"e": 3}},
-                    {"a": {"b": 2, "c": 3}, "d": {"e": 4}},
-                    {"a": {"b": 3, "c": 4}, "d": {"e": 5}},
-                ],
-                {"a": {"b": [1, 2, 3], "c": [2, 3, 4]}, "d": {"e": [3, 4, 5]}},
-            ),
-            pytest.param([{"a": 1}, {"a": 2}, {"a": 3}], {"a": [1, 2, 3]}),
-        ),
-    )
-    def test_transform_nested(self, mapping, expected):
-        actual = attitude.transform_nested(mapping)
-
-        assert actual == expected
-
-    @pytest.mark.parametrize(
         ["dim", "var", "expected"],
         (
             pytest.param("x", 1, ("x", 1, {})),

--- a/ceos_alos2/tests/test_sar_leader.py
+++ b/ceos_alos2/tests/test_sar_leader.py
@@ -941,3 +941,62 @@ class TestDataQualitySummary:
         actual = data_quality_summary.transform_relative(mapping, key)
 
         assert actual == expected
+
+    @pytest.mark.parametrize(
+        ["mapping", "expected"],
+        (
+            pytest.param(
+                {"a": {"spare1": ""}, "blanks": ""},
+                Group(
+                    path=None,
+                    url=None,
+                    data={"a": Group(path=None, url=None, data={}, attrs={})},
+                    attrs={},
+                ),
+                id="spares",
+            ),
+            pytest.param(
+                {"preamble": {}, "record_number": 1},
+                Group(path=None, url=None, data={}, attrs={}),
+                id="ignored",
+            ),
+            pytest.param(
+                {
+                    "relative_radiometric_quality": {
+                        "nominal_relative_radiometric_calibration_uncertainty": [{"a": 1}, {"a": 2}]
+                    },
+                    "relative_geometric_quality": {
+                        "relative_misregistration_error": [
+                            {"b": (-1, {"b": 1})},
+                            {"b": (-2, {"b": 1})},
+                            {"b": (-3, {"b": 1})},
+                        ]
+                    },
+                },
+                Group(
+                    path=None,
+                    url=None,
+                    data={
+                        "relative_radiometric_quality": Group(
+                            path=None,
+                            url=None,
+                            data={"a": Variable("channel", [1, 2], {})},
+                            attrs={},
+                        ),
+                        "relative_geometric_quality": Group(
+                            path=None,
+                            url=None,
+                            data={"b": Variable("channel", [-1, -2, -3], {"b": 1})},
+                            attrs={},
+                        ),
+                    },
+                    attrs={},
+                ),
+                id="transformed",
+            ),
+        ),
+    )
+    def test_transform_summary(self, mapping, expected):
+        actual = data_quality_summary.transform_summary(mapping)
+
+        assert_identical(actual, expected)

--- a/ceos_alos2/tests/test_sar_leader.py
+++ b/ceos_alos2/tests/test_sar_leader.py
@@ -4,6 +4,7 @@ import pytest
 from ceos_alos2.hierarchy import Group, Variable
 from ceos_alos2.sar_leader import (
     attitude,
+    data_quality_summary,
     dataset_summary,
     map_projection,
     platform_position,
@@ -913,3 +914,30 @@ class TestRadiometricData:
         actual = radiometric_data.transform_radiometric_data(mapping)
 
         assert_identical(actual, expected)
+
+
+class TestDataQualitySummary:
+    @pytest.mark.parametrize(
+        ["mapping", "key", "expected"],
+        (
+            pytest.param(
+                {
+                    "a": [
+                        {"b": (1, {"u": "v"}), "c": (-1, {"u": "v"})},
+                        {"b": (2, {"u": "v"}), "c": (-2, {"u": "v"})},
+                    ]
+                },
+                "a",
+                {"b": ("channel", [1, 2], {"u": "v"}), "c": ("channel", [-1, -2], {"u": "v"})},
+            ),
+            pytest.param(
+                {"f1": [{"r": 1, "o": (-1, {"a": "e"})}, {"r": 2, "o": (-2, {"a": "e"})}]},
+                "f1",
+                {"r": ("channel", [1, 2], {}), "o": ("channel", [-1, -2], {"a": "e"})},
+            ),
+        ),
+    )
+    def test_transform_relative(self, mapping, key, expected):
+        actual = data_quality_summary.transform_relative(mapping, key)
+
+        assert actual == expected

--- a/ceos_alos2/tests/test_transformers.py
+++ b/ceos_alos2/tests/test_transformers.py
@@ -55,6 +55,30 @@ def test_item_type(value, expected):
 
 
 @pytest.mark.parametrize(
+    ["mapping", "expected"],
+    (
+        pytest.param(
+            [{"a": {"b": 1, "c": 2}}, {"a": {"b": 2, "c": 3}}, {"a": {"b": 3, "c": 4}}],
+            {"a": {"b": [1, 2, 3], "c": [2, 3, 4]}},
+        ),
+        pytest.param(
+            [
+                {"a": {"b": 1, "c": 2}, "d": {"e": 3}},
+                {"a": {"b": 2, "c": 3}, "d": {"e": 4}},
+                {"a": {"b": 3, "c": 4}, "d": {"e": 5}},
+            ],
+            {"a": {"b": [1, 2, 3], "c": [2, 3, 4]}, "d": {"e": [3, 4, 5]}},
+        ),
+        pytest.param([{"a": 1}, {"a": 2}, {"a": 3}], {"a": [1, 2, 3]}),
+    ),
+)
+def test_transform_nested(mapping, expected):
+    actual = transformers.transform_nested(mapping)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
     ["value", "expected"],
     (
         pytest.param(

--- a/ceos_alos2/tests/test_transformers.py
+++ b/ceos_alos2/tests/test_transformers.py
@@ -89,6 +89,10 @@ def test_transform_nested(mapping, expected):
             [(6, {"cba": "fed"}), (2, {"cba": "fed"}), (3, {"cba": "fed"})],
             ([6, 2, 3], {"cba": "fed"}),
         ),
+        pytest.param(
+            [6, 2, 3],
+            ([6, 2, 3], {}),
+        ),
     ),
 )
 def test_separate_attrs(value, expected):

--- a/ceos_alos2/transformers.py
+++ b/ceos_alos2/transformers.py
@@ -1,6 +1,7 @@
 import datetime as dt
 
-from tlz.dicttoolz import keyfilter, valmap
+from tlz.dicttoolz import keyfilter, merge_with, valmap
+from tlz.functoolz import curry, pipe
 from tlz.itertoolz import groupby, second
 
 from ceos_alos2.hierarchy import Group, Variable
@@ -40,6 +41,20 @@ def item_type(item):
         return "group"
     else:
         return "attribute"
+
+
+def transform_nested(mapping):
+    def _transform(value):
+        if not isinstance(value, list) or not value or not isinstance(value[0], dict):
+            return value
+
+        return merge_with(list, *value)
+
+    return pipe(
+        mapping,
+        curry(_transform),
+        curry(valmap, _transform),
+    )
 
 
 def separate_attrs(data):

--- a/ceos_alos2/transformers.py
+++ b/ceos_alos2/transformers.py
@@ -58,6 +58,9 @@ def transform_nested(mapping):
 
 
 def separate_attrs(data):
+    if not isinstance(data, list) or not data or not isinstance(data[0], tuple):
+        return data, {}
+
     values, metadata_ = zip(*data)
     metadata = metadata_[0]
 


### PR DESCRIPTION
- [x] towards #29

For this record, all of the files I checked only have a few fields set (other than the preamble), all the others are missing. The ones that are set are:
- record number (record metadata, ignored)
- number of channels
- islr
- pslr
- azimuth ambiguity rate
- range ambiguity rate
- estimate of the signal-to-noise-ratio
- slant range resolution
- azimuth resolution

This means that we could possibly ignore all those fields instead of propagating always-missing data (which is what the transformer currently does).