### PR TITLE
organize the metadata in the facility-related data records

### DIFF
--- a/ceos_alos2/sar_leader/facility_related_data.py
+++ b/ceos_alos2/sar_leader/facility_related_data.py
@@ -111,6 +111,27 @@ facility_related_data_5_record = Struct(
 )
 
 
+def transform_auxiliary_file(mapping):
+    ignored = ["preamble"]
+
+    data_types = {
+        1: "dummy data",
+        2: "determined ephemeris",
+        3: "time error information",
+        4: "coordinate conversion information",
+    }
+    transformers = {"record_sequence_number": data_types.get}
+    translations = {"record_sequence_number": "data_type"}
+
+    return pipe(
+        mapping,
+        curry(remove_spares),
+        curry(dissoc, ignored),
+        curry(apply_to_items, transformers),
+        curry(rename, translations=translations),
+    )
+
+
 def transform_group(mapping, dim):
     def attach_dim(value):
         if not isinstance(value, list):

--- a/ceos_alos2/sar_leader/facility_related_data.py
+++ b/ceos_alos2/sar_leader/facility_related_data.py
@@ -1,4 +1,4 @@
-from construct import Bytes, Enum, Struct, this
+from construct import Enum, Struct, this
 from tlz.dicttoolz import valmap
 from tlz.functoolz import curry, pipe
 
@@ -12,7 +12,7 @@ facility_related_data_record = Struct(
     "preamble" / record_preamble,
     "record_sequence_number" / AsciiInteger(4),
     "blanks" / PaddedString(50),
-    "raw_file_data" / Bytes(this.preamble.record_length - 12 - 4 - 50),
+    "raw_file_data" / PaddedString(this.preamble.record_length - 12 - 4 - 50),
 )
 facility_related_data_5_record = Struct(
     "preamble" / record_preamble,


### PR DESCRIPTION
- [x] towards #29

While it does design a transformer for records 1-4, these are either empty or dumps of files, so they would need an additional transformation (parsing + organization into groups / variables) to be able to include them into a `DataTree` object. As such, they will be skipped for now.

Edit: no tests for the transformer for records 1-4, though