### PR TITLE
integerate the different parts into the high-level opener

### DIFF
--- a/ceos_alos2/io.py
+++ b/ceos_alos2/io.py
@@ -3,24 +3,23 @@ from tlz.functoolz import curry
 
 from ceos_alos2 import sar_image
 from ceos_alos2.hierarchy import Group
-
-# from ceos_alos2.sar_leader import sar_leader_record
+from ceos_alos2.sar_leader import open_sar_leader
 from ceos_alos2.summary import open_summary
-
-# from ceos_alos2.volume_directory import volume_directory_record
+from ceos_alos2.volume_directory import open_volume_directory
 
 
 def open(path, *, storage_options={}, create_cache=False, use_cache=True, records_per_chunk=1024):
     mapper = fsspec.get_mapper(path, **storage_options)
 
     # read summary
-    # TODO: split into metadata for the reader and human-readable metadata
     summary = open_summary(mapper, "summary.txt")
 
     filenames = summary["product_information"]["data_files"].attrs
 
     # read volume directory
+    volume_directory = open_volume_directory(mapper, filenames["volume_directory"])
     # read sar leader
+    sar_leader = open_sar_leader(mapper, filenames["sar_leader"])
     # read actual imagery
     imagery_groups = list(
         map(
@@ -38,43 +37,6 @@ def open(path, *, storage_options={}, create_cache=False, use_cache=True, record
         "/imagery", url=mapper.root, data={group.name: group for group in imagery_groups}, attrs={}
     )
     # read sar trailer
+    subgroups = {"summary": summary, "metadata": sar_leader, "imagery": imagery}
 
-    subgroups = {"imagery": imagery, "summary": summary}
-
-    return Group(path="/", data=subgroups, url=mapper.root, attrs={})
-
-
-# try:
-#     with self.fs.open(fnames["volume_directory"], mode="rb") as f:
-#         parsed = volume_directory.volume_directory_record.parse(f.read())
-#         vol_attrs = volume_directory.extract_metadata(parsed)
-# except FileNotFoundError as e:
-#     raise OSError(
-#         f"Cannot find the volume directory file (`{fnames['volume_directory']}`)."
-#         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
-#     )
-
-# try:
-#     with self.fs.open(fnames["sar_leader"], mode="rb") as f:
-#         sar_leader = sar_leader_record.parse(f.read())
-# except FileNotFoundError as e:
-#     raise OSError(
-#         f"Cannot find the sar leader file (`{fnames['sar_leader']}`)."
-#         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
-#     )
-
-# image_groups = {
-#     sar_image.filename_to_groupname(path): self.read_image(self.fs, path)
-#     for path in fnames["sar_imagery"]
-# }
-
-# self._groups = image_groups
-
-# try:
-#     with dirfs.open(fnames["sar_trailer"], mode="rb") as f:
-#         trailer_header, image_ranges = read_sar_trailer_metadata(f)
-# except FileNotFoundError as e:
-#     raise OSError(
-#         f"Cannot find the sar trailer file (`{fnames['sar_trailer']}`)."
-#         f" Make sure the dataset at {url} is complete and in the JAXA CEOS format."
-#     )
+    return Group(path="/", data=subgroups, url=mapper.root, attrs=volume_directory.attrs)

--- a/ceos_alos2/sar_leader/metadata.py
+++ b/ceos_alos2/sar_leader/metadata.py
@@ -1,6 +1,7 @@
 import numpy as np
 from tlz.dicttoolz import valfilter
 from tlz.functoolz import compose_left, curry, pipe
+from tlz.itertoolz import first
 
 from ceos_alos2.dicttoolz import apply_to_items, dissoc
 from ceos_alos2.hierarchy import Group, Variable
@@ -39,7 +40,7 @@ def transform_metadata(mapping):
     ]
     transformers = {
         "dataset_summary": transform_dataset_summary,
-        "map_projection": transform_map_projection,
+        "map_projection": compose_left(first, transform_map_projection),
         "platform_position": transform_platform_position,
         "attitude": transform_attitude,
         "radiometric_data": transform_radiometric_data,

--- a/ceos_alos2/tests/test_sar_leader.py
+++ b/ceos_alos2/tests/test_sar_leader.py
@@ -1384,7 +1384,7 @@ class TestMetadata:
                 id="transformed-dataset_summary",
             ),
             pytest.param(
-                {"map_projection": {"map_projection_general_information": {}}},
+                {"map_projection": [{"map_projection_general_information": {}}]},
                 Group(
                     path=None,
                     url=None,

--- a/ceos_alos2/volume_directory/__init__.py
+++ b/ceos_alos2/volume_directory/__init__.py
@@ -1,1 +1,1 @@
-from ceos_alos2.volume_directory.structure import volume_directory_record  # noqa: F401
+from ceos_alos2.volume_directory.io import open_volume_directory  # noqa: F401


### PR DESCRIPTION
- [x] towards #17

With the different file types parsed into a consistent structure, we can integrate everything into the high-level dataset open function.

No tests, yet, because I'm not sure how to best test this without monkeypatching too much.