### PR TITLE
documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ __pycache__/
 .coverage.*
 .cache
 /docs/_build/
+/docs/generated/
+/docs/warnings.log

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_checkout:
+      - (git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]") || exit 183
+      - git fetch --unshallow || true
+    pre_install:
+      - git update-index --assume-unchanged doc/conf.py ci/requirements/doc.yml
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true

--- a/ceos_alos2/xarray.py
+++ b/ceos_alos2/xarray.py
@@ -87,7 +87,37 @@ def to_datatree(group, chunks=None):
     return datatree.DataTree.from_dict(mapping)
 
 
-def open_alos2(path, chunks=None, storage_options={}, backend_options={}):
-    root = io.open(path, storage_options=storage_options, **backend_options)
+def open_alos2(path, chunks=None, backend_options={}):
+    """Open CEOS ALOS2 datasets
+
+    Parameters
+    ----------
+    path : str
+        Path or URL to the dataset.
+    chunks : int, dict, "auto" or None, optional
+        If chunks is provided, it is used to load the new dataset into dask
+        arrays. ``chunks=-1`` loads the dataset with dask using a single chunk
+        for all arrays. ``chunks={}`` loads the dataset with dask using engine
+        preferred chunks if exposed by the backend, otherwise with a single
+        chunk for all arrays. ``chunks='auto'`` will use dask ``auto`` chunking
+        taking into account the engine preferred chunks. See dask chunking for
+        more details.
+    backend_options : dict, optional
+        Additional keyword arguments passed on to the low-level open function:
+
+        - 'storage_options': Additional arguments for `fsspec.get_mapper`
+        - 'use_cache': Make use of image cache files, if they exist. Default: True
+        - 'create_cache': Create a local cache file after reading the image
+          metadata. Default: False
+        - 'records_per_chunk': The image metadata is stored line by line. In order to
+          avoid sending potentially thousands of requests, read this many lines
+          at once. Default: 1024
+
+    Returns
+    -------
+    tree : datatree.DataTree
+        The newly created datatree.
+    """
+    root = io.open(path, **backend_options)
 
     return to_datatree(root, chunks=chunks)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,9 @@
+API
+===
+
+.. currentmodule:: ceos_alos2
+
+.. autosummary::
+   :toctree: generated/
+
+   open_alos2

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2023.08.1 (_unreleased_)
+
+## 2023.08.0 (25 Aug 2023)
+
+Initial release.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # -- Project information -----------------------------------------------------
 import datetime as dt
 
-project = "xarray-alos2"
+project = "xarray-ceos-alos2"
 author = f"{project} developers"
 initial_year = "2023"
 year = dt.datetime.now().year

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,8 +16,12 @@ root_doc = "index"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "myst_parser",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
     "IPython.sphinxext.ipython_directive",
     "IPython.sphinxext.ipython_console_highlighting",
 ]
@@ -53,4 +57,22 @@ html_theme = "sphinx_book_theme"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/stable/", None),
+    "xarray": ("https://docs.xarray.dev/en/latest/", None),
+    "datatree": ("https://xarray-datatree.readthedocs.io/en/latest/", None),
 }
+
+
+# -- Options for the autosummary extension -----------------------------------
+
+autosummary_generate = True
+autodoc_typehints = "none"
+napoleon_use_param = False
+napoleon_use_rtype = True
+
+napoleon_preprocess_types = True
+napoleon_type_aliases = {}
+
+
+# -- Options for the myst-parser extension -----------------------------------
+
+myst_enable_extensions = ["colon_fence"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# xarray-ceos-alos2
+
+`xarray-ceos-alos2` allows reading CEOS ALOS2 datasets (for now, level 1.1, 1.5, and 3.1 only) into [datatree](https://github.com/xarray-contrib/datatree) objects.
+
+**Contents**:
+
+- {doc}`Installing <installing>`
+- {doc}`Changelog <changelog>`
+- {doc}`Usage <usage>`
+- {doc}`API <api>`
+
+:::{toctree}
+:caption: Contents
+:maxdepth: 1
+:hidden:
+
+installing.md
+changelog.md
+usage.md
+api.rst
+:::

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,0 +1,14 @@
+# Installing
+
+1. Install from [PyPI](https://pypi.org):
+
+```sh
+pip install xarray-ceos-alos2
+```
+
+2. Install from [conda-forge](https://conda-forge.org)
+
+```sh
+conda activate <env>
+conda install -c conda-forge xarray-ceos-alos2
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,12 @@
-sphinx>=4
-sphinx_book_theme
+sphinx>=6
+sphinx_book_theme>=0.3
+myst-parser
 ipython
+numpy
+toolz
+cytoolz
+python-dateutil
+construct
+fsspec
+xarray
+xarray-datatree

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,75 @@
+# Usage
+
+## Opening datasets
+
+Datasets of levels 1.1, 1.5, or 3.1 can be opened using:
+
+```python
+import ceos_alos2
+
+url = "..."
+tree = ceos_alos2.open_alos2(url, chunks={})
+```
+
+## Backend options
+
+Additional parameters can be set using the `backend_options` parameter. The valid options are:
+
+- `storage_options`: additional parameters passed on to the appropriate `fsspec` filesystem
+- `records_per_chunk`: request size when fetching image data (see {ref}`request-size`)
+- `use_cache`: use cache files instead of parsing the image files (see {ref}`caching`)
+- `create_cache`: create cache files (see {ref}`caching`)
+
+## Access optimizations
+
+(request-size)=
+
+### Request size
+
+The image data of CEOS ALOS2 datasets is subdivided into records that represent the lines (rows) of the image. Each record begins with metadata, followed by the actual line data.
+
+However, this is not optimized for the typical data access pattern: when opening the dataset, all the metadata is read, and once computations on the image are performed the image data is accessed separately. Thus, each record is requested at least twice, once when collecting the metadata and at least once when computing the image data. Additionally, requesting the records one-by-one means that tens of thousands of requests (or syscalls in case of a local file system) have to performed, which can take a very long time.
+
+Using the `records_per_chunk` setting, a number of records can be grouped and requested together. This allows reducing the number of requests by a lot, which in turn makes data access much faster.
+
+:::{tip}
+Always specify the request size explicitly
+:::
+
+For example:
+
+```python
+tree = ceos_alos2.open_alos2(url, chunks={}, backend_options={"records_per_chunk": 4096})
+```
+
+(caching)=
+
+### Caching
+
+Even though adjusting the request size can decrease access times, reading and parsing the image metadata still takes a lot of time (in the case of level 1.1 ScanSAR this can take more than 10 minutes). To avoid that, it is possible to save the metadata in special cache files, allowing to open datasets (i.e. reading the file metadata) in a matter of seconds.
+
+The `use_cache` parameter controls whether or not these cache files are used, which can be stored either alongside the image file (i.e. a "remote cache file") or in a local directory (`$user_cache_dir/xarray-ceos-alos2/<hash-of-dataset-url>/<image>.index`, where `$user_cache_dir` depends on the OS). If both exist the remote cache file is preferred.
+
+Cache files can be created either by enabling the `create_cache` flag or by running the `ceos-alos2-create-cache` executable.
+
+Using `create_cache`:
+
+```python
+tree = ceos_alos2.open_alos2(
+    url,
+    chunks={},
+    backend_options={"records_per_chunk": 4096, "create_cache": True, "use_cache": False},
+)
+```
+
+This will open the dataset with a request size of 4096 records and write a local cache file for _each image_.
+
+Using `ceos-alos2-create-cache`:
+
+```sh
+ceos-alos2-create-cache --rpc 4096 <image-path>
+# or, with a explict target path
+ceos-alos2-create-cache --rpc 4096 <image-path> <target-path>
+```
+
+This will open a _single_ image with a request size of 4096 records and create a cache file, either in the specified target path, or adjacent to the image file.


### PR DESCRIPTION
- [x] closes #39

First version of the documentation. Should be mostly complete, but it references a (as-of now) non-existent `ceos-alos2-create-cache` executable which should be added in another PR (it involves refactoring `ceos_alos2/sar_image/__main__.py`).