### PR TITLE
fix the `dirfs` comparisons

### DIFF
--- a/ceos_alos2/sar_image/__init__.py
+++ b/ceos_alos2/sar_image/__init__.py
@@ -22,12 +22,9 @@ def open_image(mapper, path, *, use_cache=True, create_cache=False, records_per_
         except CachingError:
             pass
 
-    try:
-        fs = mapper.dirfs
-    except AttributeError:
-        from fsspec.implementations.dirfs import DirFileSystem
+    from fsspec.implementations.dirfs import DirFileSystem
 
-        fs = DirFileSystem(fs=mapper.fs, path=mapper.root)
+    fs = DirFileSystem(path=mapper.root, fs=mapper.fs)
 
     with fs.open(path, mode="rb") as f:
         header, metadata = read_metadata(f, records_per_chunk)

--- a/ceos_alos2/sar_image/caching/decoders.py
+++ b/ceos_alos2/sar_image/caching/decoders.py
@@ -34,12 +34,9 @@ def decode_array(encoded, records_per_chunk):
         return decoder(encoded)
 
     mapper = fsspec.get_mapper(encoded["root"])
-    try:
-        fs = mapper.dirfs
-    except AttributeError:
-        from fsspec.implementations.dirfs import DirFileSystem
+    from fsspec.implementations.dirfs import DirFileSystem
 
-        fs = DirFileSystem(fs=mapper.fs, path=mapper.root)
+    fs = DirFileSystem(path=mapper.root, fs=mapper.fs)
 
     type_code = encoded["type_code"]
     url = encoded["url"]

--- a/ceos_alos2/tests/utils.py
+++ b/ceos_alos2/tests/utils.py
@@ -18,7 +18,7 @@ def create_dummy_array(
         byte_ranges = [(x * 10 + 5, (x + 1) * 10) for x in range(shape[0])]
 
     fs = fsspec.filesystem(protocol)
-    dirfs = fsspec.filesystem("dir", fs=fs, path=path)
+    dirfs = fsspec.filesystem("dir", path=path, fs=fs)
 
     return Array(
         fs=dirfs,


### PR DESCRIPTION
- [x] fixes the failing tests on `main`

I had some time to look into this today, and as it turns out, the reason for the failures is that `DirFileSystem` instances don't compare equal if the arguments differ slightly or they're passed in a different order. To avoid that, we stop trying to use `mapper.dirfs` which allows us to get full control over the way the `dirfs` instance is constructed.