### PR TITLE
use `xarray`'s version of `DataTree`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xarray-ceos-alos2
 
-Read ALOS2 CEOS files into `datatree` objects.
+Read ALOS2 CEOS files into `xarray.DataTree` objects.
 
 ## Installation
 

--- a/ceos_alos2/tests/test_xarray.py
+++ b/ceos_alos2/tests/test_xarray.py
@@ -1,5 +1,3 @@
-import datatree
-import datatree.testing
 import numpy as np
 import pytest
 import xarray as xr
@@ -168,7 +166,7 @@ def test_to_dataset(group, chunks, expected):
                 },
                 attrs={"coordinates": ["d"]},
             ),
-            datatree.DataTree.from_dict(
+            xr.DataTree.from_dict(
                 {
                     "/": xr.Dataset(
                         {"c": ("x", [1, 2, 3], {"a": 1})},
@@ -193,7 +191,7 @@ def test_to_dataset(group, chunks, expected):
                 },
                 attrs={},
             ),
-            datatree.DataTree.from_dict(
+            xr.DataTree.from_dict(
                 {
                     "/": xr.Dataset({"c": ("x", [1, 2, 3], {"a": 1})}),
                     "d": xr.Dataset({"e": (["x", "y"], np.arange(12).reshape(3, 4), {"b": "abc"})}),
@@ -206,4 +204,4 @@ def test_to_dataset(group, chunks, expected):
 def test_to_datatree(group, chunks, expected):
     actual = xarray.to_datatree(group, chunks=chunks)
 
-    datatree.testing.assert_identical(actual, expected)
+    xr.testing.assert_identical(actual, expected)

--- a/ceos_alos2/xarray.py
+++ b/ceos_alos2/xarray.py
@@ -1,4 +1,3 @@
-import datatree
 import numpy as np
 import numpy.typing
 import xarray as xr
@@ -76,7 +75,7 @@ def to_datatree(group, chunks=None):
     mapping = {"/": to_dataset(group, chunks=chunks)} | {
         path: to_dataset(subgroup, chunks=chunks) for path, subgroup in group.subtree
     }
-    return datatree.DataTree.from_dict(mapping)
+    return xr.DataTree.from_dict(mapping)
 
 
 def open_alos2(path, chunks=None, backend_options={}):
@@ -107,7 +106,7 @@ def open_alos2(path, chunks=None, backend_options={}):
 
     Returns
     -------
-    tree : datatree.DataTree
+    tree : xarray.DataTree
         The newly created datatree.
     """
     root = io.open(path, **backend_options)

--- a/ci/install-upstream-dev.sh
+++ b/ci/install-upstream-dev.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+if command -v micromamba >/dev/null; then
+  conda=micromamba
+elif command -v mamba >/dev/null; then
+  conda=mamba
+else
+  conda=conda
+fi
 conda remove -y --force cytoolz numpy xarray construct toolz fsspec python-dateutil pandas
 python -m pip install \
   -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \

--- a/ci/install-upstream-dev.sh
+++ b/ci/install-upstream-dev.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-conda remove -y --force cytoolz numpy xarray construct toolz xarray-datatree fsspec python-dateutil pandas
+conda remove -y --force cytoolz numpy xarray construct toolz fsspec python-dateutil pandas
 python -m pip install \
   -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
   --no-deps \
@@ -12,6 +12,5 @@ python -m pip install \
 python -m pip install --upgrade \
   git+https://github.com/construct/construct \
   git+https://github.com/pytoolz/toolz \
-  git+https://github.com/xarray-contrib/datatree \
   git+https://github.com/fsspec/filesystem_spec \
   git+https://github.com/dateutil/dateutil

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -14,7 +14,6 @@ dependencies:
   - construct
   - fsspec
   - xarray
-  - xarray-datatree
   - dask
   - distributed
   - aiohttp

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -13,7 +13,7 @@ dependencies:
   - python-dateutil
   - construct
   - fsspec
-  - xarray
+  - xarray>=2024.10.0
   - dask
   - distributed
   - aiohttp

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,6 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/stable/", None),
     "xarray": ("https://docs.xarray.dev/en/latest/", None),
-    "datatree": ("https://xarray-datatree.readthedocs.io/en/latest/", None),
 }
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # xarray-ceos-alos2
 
-`xarray-ceos-alos2` allows reading CEOS ALOS2 datasets (for now, level 1.1, 1.5, and 3.1 only) into [datatree](https://github.com/xarray-contrib/datatree) objects.
+`xarray-ceos-alos2` allows reading CEOS ALOS2 datasets (for now, level 1.1, 1.5, and 3.1 only) into {py:class}`xarray.DataTree` objects.
 
 **Contents**:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,5 @@ cytoolz
 python-dateutil
 construct
 fsspec
-xarray
-xarray-datatree
+xarray>=2024.10.0
 platformdirs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 dependencies = [
   "toolz",
   "python-dateutil",
-  "xarray",
+  "xarray>=2024.10.0",
   "numpy",
   "construct>=2.10",
   "fsspec",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
   "toolz",
   "python-dateutil",
   "xarray",
-  "xarray-datatree",
   "numpy",
   "construct>=2.10",
   "fsspec",


### PR DESCRIPTION
- [x] closes #74

Turns out this was really easy: replace the import and everything works as usual, but with the version in `xarray` (and thus with some improvements).