### PR TITLE
release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## 2024.10.0 (_unreleased_)
 
+- migrate to {py:class}`xarray.DataTree` ({pull}`81`)
+
 ## 2023.08.2 (28 Aug 2023)
 
 - explicitly add `platformdirs` to the dependencies ({pull}`57`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## 2024.10.0 (_unreleased_)
 
 - migrate to {py:class}`xarray.DataTree` ({pull}`81`)
+- support `python=3.12` ({pull}`82`)
 
 ## 2023.08.2 (28 Aug 2023)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2023.08.3 (_unreleased_)
+## 2024.10.0 (_unreleased_)
 
 ## 2023.08.2 (28 Aug 2023)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2024.10.0 (_unreleased_)
+## 2024.10.0 (30 Oct 2024)
 
 - migrate to {py:class}`xarray.DataTree` ({pull}`81`)
 - support `python=3.12` ({pull}`82`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering",
 ]


### PR DESCRIPTION
The migration from `datatree` to `xarray` is big enough that we should release the reader (which didn't happen in the last year).