### PR TITLE
officially support `python=3.13`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.12", "3.13"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     steps:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ## 2025.05.0 (_unreleased_)
 
 - support `python=3.13` ({pull}`99`)
+- don't decode facility-related data records 1-4 ({pull}`98`)
 
 ## 2024.10.0 (30 Oct 2024)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025.05.0 (_unreleased_)
+
+- support `python=3.13` ({pull}`99`)
+
 ## 2024.10.0 (30 Oct 2024)
 
 - migrate to {py:class}`xarray.DataTree` ({pull}`81`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering",
 ]


### PR DESCRIPTION
(might also have to retire `python=3.10` soon, as `xarray` is considering to discontinue support)