### PR TITLE
Compatibility wiith fsspec > 2025.10.0

### DIFF
--- a/ceos_alos2/tests/test_testing.py
+++ b/ceos_alos2/tests/test_testing.py
@@ -1,3 +1,4 @@
+import fsspec
 import numpy as np
 import pytest
 
@@ -191,12 +192,22 @@ def test_compare_data(left, right, expected):
         pytest.param(
             create_dummy_array(protocol="http"),
             create_dummy_array(protocol="memory"),
-            "\n".join(
-                [
-                    "Differing filesystem:",
-                    "  L protocol  http",
-                    "  R protocol  memory",
-                ]
+            (
+                "\n".join(
+                    [
+                        "Differing filesystem:",
+                        "  L protocol  'http'",
+                        "  R protocol  memory",
+                    ]
+                )
+                if fsspec.__version__ < "2025.10.0"
+                else "\n".join(
+                    [
+                        "Differing filesystem:",
+                        "  L protocol  ('http', 'https')",
+                        "  R protocol  memory",
+                    ]
+                )
             ),
             id="array-fs-protocol",
         ),


### PR DESCRIPTION
When I run the test suite in Debian Sid I get the following error:

```
python3.13 -m pytest --pyargs ceos_alos2
============================= test session starts ==============================
platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /build/xarray-ceos-alos2-2025.05.0/.pybuild/cpython3_3.13_ceos_alos2/build
configfile: pyproject.toml
plugins: typeguard-4.4.4
collected 1224 items

[CUT]

=================================== FAILURES ===================================
______________________ test_diff_array[array-fs-protocol] ______________________

left = Array(url='file', shape=(4, 3), dtype='int16', records_per_chunk=2)
right = Array(url='file', shape=(4, 3), dtype='int16', records_per_chunk=2)
expected = 'Differing filesystem:\n  L protocol  http\n  R protocol  memory'

    @pytest.mark.parametrize(
        ["left", "right", "expected"],
        (
            pytest.param(
                np.array([1], dtype="int32"),
                np.array([2, 3], dtype="int8"),
                "\n".join(["  L int32  1", "  R int8  2 3"]),
                id="numpy",
            ),
            pytest.param(
                create_dummy_array(protocol="http"),
                create_dummy_array(protocol="memory"),
                "\n".join(
                    [
                        "Differing filesystem:",
                        "  L protocol  http",
                        "  R protocol  memory",
                    ]
                ),
                id="array-fs-protocol",
            ),
            pytest.param(
                create_dummy_array(path="/path/to1"),
                create_dummy_array(path="/path/to2"),
                "\n".join(
                    [
                        "Differing filesystem:",
                        "  L path  /path/to1",
                        "  R path  /path/to2",
                    ]
                ),
                id="array-fs-path",
            ),
            pytest.param(
                create_dummy_array(url="file1"),
                create_dummy_array(url="file2"),
                "\n".join(
                    [
                        "Differing urls:",
                        "  L url  file1",
                        "  R url  file2",
                    ]
                ),
                id="array-url",
            ),
            pytest.param(
                create_dummy_array(byte_ranges=[(0, 1), (2, 3), (3, 4), (4, 5)]),
                create_dummy_array(byte_ranges=[(0, 2), (2, 3), (3, 4), (4, 5)]),
                "\n".join(
                    [
                        "Differing byte ranges:",
                        "  L line 1  (0, 1)",
                        "  R line 1  (0, 2)",
                    ]
                ),
                id="array-byte_ranges",
            ),
            pytest.param(
                create_dummy_array(shape=(4, 3), byte_ranges=[]),
                create_dummy_array(shape=(6, 3), byte_ranges=[]),
                "\n".join(
                    [
                        "Differing shapes:",
                        "  (4, 3) != (6, 3)",
                    ]
                ),
                id="array-shape",
            ),
            pytest.param(
                create_dummy_array(dtype="int8"),
                create_dummy_array(dtype="int16"),
                "\n".join(
                    [
                        "Differing dtypes:",
                        "  int8 != int16",
                    ]
                ),
                id="array-dtype",
            ),
            pytest.param(
                create_dummy_array(type_code="IU2"),
                create_dummy_array(type_code="C*8"),
                "\n".join(
                    [
                        "Differing type code:",
                        "  L type_code  IU2",
                        "  R type_code  C*8",
                    ]
                ),
                id="array-type_code",
            ),
            pytest.param(
                create_dummy_array(records_per_chunk=2),
                create_dummy_array(records_per_chunk=1),
                "\n".join(
                    [
                        "Differing chunksizes:",
                        "  L records_per_chunk  2",
                        "  R records_per_chunk  1",
                    ]
                ),
                id="array-rpc",
            ),
        ),
    )
    def test_diff_array(left, right, expected):
        actual = testing.diff_array(left, right)
    
>       assert actual == expected
E       AssertionError: assert 'Differing fi...tocol  memory' == 'Differing fi...tocol  memory'
E         
E           Differing filesystem:
E         -   L protocol  http
E         +   L protocol  ('http', 'https')
E             R protocol  memory

ceos_alos2/tests/test_testing.py:290: AssertionError
=============================== warnings summary ===============================
ceos_alos2/tests/test_summary.py::test_categorize_filenames[short]
  /usr/lib/python3/dist-packages/_pytest/raises.py:622: PytestWarning: matching against an empty string will *always* pass. If you want to check for an empty message you need to pass '^$'. If you don't want to match you should pass `None` or leave out the parameter.
    super().__init__(match=match, check=check)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED ceos_alos2/tests/test_testing.py::test_diff_array[array-fs-protocol]
============= 1 failed, 1222 passed, 1 skipped, 1 warning in 2.39s =============
```

Apparently it is something related to a change of behaviour in `fsspec`.
I'm using fsspec v2025.12.0.

The issue is only in the test code and the fix provided in this PR is quite simple.